### PR TITLE
Fix Dependabot vulnerabilities and refresh docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,13 +5,13 @@
 ```bash
 git clone https://github.com/jordanstarrk/mcp-preflight.git
 cd mcp-preflight
-uv sync --all-extras
+uv sync --dev
 ```
 
 ## Running tests
 
 ```bash
-uv run pytest           # quick pass/fail
+uv run pytest -q        # quick pass/fail
 uv run pytest -v        # verbose output
 uv run python tests/show_outputs.py   # visual check against toy servers
 ```
@@ -68,16 +68,15 @@ uv build
 uv publish
 ```
 
-`uv publish` reads the token from the `UV_PUBLISH_TOKEN` environment variable (set in `~/.zshrc`).
+`uv publish` reads the token from the `UV_PUBLISH_TOKEN` environment variable (set in your environment or CI secrets).
 
 ### PyPI token setup (one-time)
 
-1. Generate a token at https://pypi.org/manage/account/token/ (scoped to `mcp-preflight`)
-2. Add to your shell profile:
+1. Generate a token at `https://pypi.org/manage/account/token/` (scoped to `mcp-preflight`)
+2. Export it for the current shell session (or store it in CI secrets):
 
 ```bash
-echo 'export UV_PUBLISH_TOKEN="pypi-..."' >> ~/.zshrc
-source ~/.zshrc
+export UV_PUBLISH_TOKEN="pypi-..."
 ```
 
 ### 6. Verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,11 @@ jobs:
       - name: Run tests
         run: uv run pytest -q
 
+      - name: Verify committed MCP surface baseline
+        run: |
+          # This intentionally fails when the toy server's declared MCP surface
+          # changes without an accompanying baseline update.
+          uv run mcp-preflight check \
+            tests/baselines/toy-open.snapshot.json \
+            "python tests/toy_servers/toy_open.py"
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Smoke: CLI entrypoint
+        run: uv run mcp-preflight --help
+
+      - name: Run tests
+        run: uv run pytest -q
+

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -10,7 +10,7 @@ These principles describe what the tool is for, where it stops, and how scope de
 
 - Preflight provides pre-trust visibility, not enforcement or guarantees
 - Declared surfaces are preferred over inferred behavior
-- Inspection is read-only and has no side effects
+- Preflight avoids tool execution; introspection still runs server code
 - Incomplete but honest is better than complete but misleading
 - Change visibility matters more than static completeness
 

--- a/README.md
+++ b/README.md
@@ -2,33 +2,132 @@
 [![Downloads](https://static.pepy.tech/badge/mcp-preflight)](https://pepy.tech/project/mcp-preflight)
 [![PyPI version](https://img.shields.io/pypi/v/mcp-preflight.svg)](https://pypi.org/project/mcp-preflight/)
 
-`ls -la` for MCP servers. Inspect what a server declares before giving it operational access.
-`mcp-preflight` captures a server’s declared tools, schemas, resources, templates, prompts, and additional declared operations. It can save that surface as a deterministic snapshot, assign complete observations a stable SHA-256 identity, and show structural changes over time.
+Inspect, fingerprint, and diff an MCP server’s declared capability surface.
 
-## TL;DR
+An MCP server can gain tools, parameters, resources, prompts, or new actions beneath an existing tool name. `mcp-preflight` captures that client-visible surface as a deterministic snapshot, computes a stable digest when inspection is complete, and shows structural differences over time.
 
-- **Inspect**: show the client-visible MCP surface (tools, schemas, resources/templates, prompts).
-- **Snapshot**: `--save` / `--json` emit a versioned snapshot JSON you can commit.
-- **Fingerprint**: complete snapshots get a deterministic `surfaceDigest` (sha256 of the canonical surface).
-- **Diff**: `mcp-preflight diff` reports structural capability changes (not just tool-count changes).
-- **Evidence-aware comparisons**: legacy/partial inputs don’t support complete identity claims; limitations and evidence gaps are rendered explicitly.
-- **Manifest support**: can read `{scheme}://mcp/manifest` to surface multiplexed per-tool operations.
+Use it as:
 
+- an interface compatibility check for MCP server maintainers
+- a capability-change review gate for teams consuming third-party MCP servers
 
+If you want the deeper framing and experiments, see [You can’t prove an MCP server hasn’t changed](You%20can%E2%80%99t%20prove%20an%20MCP%20server%20hasn%E2%80%99t%20changed.md).
 
-## Install
+## Why
+
+You review an MCP server before installing it. Later, a dependency upgrade adds a destructive action beneath an existing tool name. The package version changed, but nothing gives you a durable, structural record of the declared capability surface you previously reviewed.
+
+`mcp-preflight` turns that declaration into a versioned artifact that can be committed, compared, and reviewed.
+
+## Quick start (snapshot + check)
 
 ```bash
 pipx install mcp-preflight
+
+# Commit a baseline snapshot (one-time)
+mcp-preflight --save mcp-surface.json "uv run server.py"
+git add mcp-surface.json
+
+# Later, locally or in CI: check the live server against the baseline
+mcp-preflight check mcp-surface.json "uv run server.py"
 ```
 
-## Quick start
+A changed surface is not automatically unsafe; `check` turns it into an explicit review event rather than allowing it to pass unnoticed.
+
+> **Safety:** This command starts the server locally. MCP discovery does not invoke its declared tools, but a server can execute arbitrary code while handling any request. Use `--isolate-home` to prevent it from using your normal `HOME` and XDG directories; this is not a sandbox.
+
+## Example change
+
+```text
+Surface changed.
+
+Tools:
+  ~ manage_items
+      inputSchema.properties.action.enum:
+        + delete
+
+Previous: sha256:...
+Current:  sha256:...
+```
+
+Structured output:
 
 ```bash
-mcp-preflight "npx @modelcontextprotocol/server-filesystem /tmp"
+mcp-preflight check --json mcp-surface.json "uv run server.py" > check.json
 ```
 
-## Example output
+## What it captures and compares
+
+- Tools, descriptions, and full input schemas
+- Schema fields, required parameters, and enum values, including changes beneath unchanged tool names
+- Resources and resource templates
+- Prompts and prompt arguments
+- Optional per-tool manifest operations for servers that multiplex actions behind one tool (see [docs/server-manifest.md](docs/server-manifest.md))
+
+## Integrations
+
+The snapshot, surface digest, and structured `check --json` output can be consumed by registries, governance systems, agent runtimes, and security gateways. These systems can anchor approval to a specific observed surface and trigger re-review when that surface changes.
+
+`mcp-preflight` supplies the inspection artifact; the consuming system decides whether to allow, block, sandbox, or require approval.
+
+## Common workflows
+
+```bash
+# Inspect (human-readable)
+mcp-preflight "uv run server.py"
+mcp-preflight "npx my-mcp-server"
+mcp-preflight "python3 /path/to/server.py"
+
+# Save a snapshot (JSON)
+mcp-preflight --save snapshot.json "uv run server.py"
+
+# Check against a baseline snapshot
+mcp-preflight check mcp-surface.json "uv run server.py"
+
+# Diff two saved snapshots
+mcp-preflight diff before.json after.json
+
+# JSON output
+mcp-preflight --json "uv run server.py"
+```
+
+## CI workflow
+
+`check` turns declared-surface changes into an explicit review step, with stable exit codes and optional structured JSON (`--json`).
+
+1. Commit a baseline snapshot (one-time).
+2. Run `mcp-preflight check ...` in CI.
+3. If the surface changed, review the diff in the PR and intentionally update the baseline snapshot.
+
+Exit codes:
+
+- **0 — unchanged**: inspection was complete and the surface digests match
+- **1 — changed**: inspection was complete and the surface digests differ
+- **2 — inspection failed**: timeout, auth required, startup error, etc.
+- **3 — incomplete inspection**: preflight could not establish a comparable surface digest
+- **4 — invalid baseline**: missing/partial baseline, unsupported snapshot version, invalid JSON
+
+Machine-readable output:
+
+```bash
+mcp-preflight check --json mcp-surface.json "uv run server.py" > check.json
+echo "exit_code=$?"
+```
+
+## Snapshots and identity
+
+Snapshots separate observation metadata from the declared surface. Only the normalized surface is hashed.
+
+A digest is emitted only when every supported identity-bearing discovery section completes successfully. An incomplete inspection produces no digest, rather than claiming a comparable identity.
+
+See [Snapshot format and normalization](docs/snapshots.md).
+
+## Interactive inspection
+
+The interactive inspect output is useful for first-time exploration, debugging, and manual review.
+
+<details>
+<summary>Example interactive inspection output</summary>
 
 ```text
 my-server (MCP 2025-03-26)
@@ -56,144 +155,9 @@ my-server (MCP 2025-03-26)
 
   Prompts:
     💬 analyze_items (project_name)
-
-  Risk summary:
-    write: 2
-    destructive: 1
-    read-only: 2
-    (best-effort heuristic from tool names/descriptions; not enforced)
 ```
 
-## Common workflows
-
-```bash
-# Run against your own server
-mcp-preflight "uv run server.py"
-mcp-preflight "npx my-mcp-server"
-mcp-preflight "python3 /path/to/server.py"
-
-# Save a snapshot (JSON)
-mcp-preflight --save snapshot.json "uv run server.py"
-
-# Diff two saved snapshots
-mcp-preflight diff before.json after.json
-
-# JSON output
-mcp-preflight --json "uv run server.py"
-```
-
-### CI-friendly usage (snapshot + diff)
-
-```bash
-# Create and commit a baseline snapshot (one-time)
-mcp-preflight --save mcp-surface.json "uv run server.py"
-git add mcp-surface.json
-
-# Later (e.g. after an upgrade): re-inspect and diff
-mcp-preflight --save mcp-surface-current.json "uv run server.py" || true
-mcp-preflight diff mcp-surface.json mcp-surface-current.json
-```
-
-Notes:
-
-- `mcp-preflight` exits **nonzero** when inspection is partial/failed, but it can still save a snapshot; `|| true` lets a CI job continue to run `diff`.
-- `mcp-preflight diff` currently prints a human diff and does not return “changed vs unchanged” via exit code.
-
-### CI gate: `mcp-preflight check`
-
-For pull-request gating, use `check` (a single command with stable exit codes):
-
-```bash
-# Create and commit a baseline snapshot (one-time)
-mcp-preflight --save mcp-surface.json "uv run server.py"
-git add mcp-surface.json
-
-# In CI / pull requests
-mcp-preflight check mcp-surface.json "uv run server.py"
-```
-
-Exit codes:
-
-- **0**: unchanged (complete identity comparable; `surfaceDigest` matches)
-- **1**: changed (complete identity comparable; `surfaceDigest` differs)
-- **2**: inspection failed (timeout, auth required, startup error, etc.)
-- **3**: inspection partial / identity incomparable
-- **4**: invalid baseline (missing/partial snapshot, unsupported snapshot version, invalid JSON)
-
-`check --json` prints a machine-readable result (suitable for CI bots and wrappers).
-
-## What changes can it detect?
-
-Snapshots can reveal changes that do not alter a tool name, including:
-
-- input fields added or removed
-- enum actions added behind an existing tool
-- required parameters changing
-- descriptions changing
-- resources, templates, prompts, or prompt arguments changing
-
-## Notes
-
-- Starts the server locally and performs MCP discovery without invoking the server’s declared tools.
-- Lists the declared tools, descriptions, input schemas, resources, resource templates, prompts, and prompt arguments returned by the server.
-- If a single tool supports multiple actions, publish a `{scheme}://mcp/manifest` resource so preflight can surface and diff them. See [server manifest docs](docs/server-manifest.md).
-
-## Snapshot JSON format
-
-`--json` and `--save` emit a **versioned snapshot**. (Older `mcp-preflight` versions emitted an unversioned “report” JSON format; snapshots are the stable format going forward.)
-
-- **`observation`**: timestamp, command, negotiated protocol version, inspection status, coverage, notes, errors, and local heuristic annotations.
-- **`surface`**: the server-declared tools, descriptions, the complete `inputSchema` returned by the server, resources, resource templates, prompts, prompt arguments, and additional declaration sources.
-
-Only `surface` is deterministically normalized and hashed.
-
-Normalization rules (high level):
-
-- Lists are sorted by identity keys (tool name, resource URI, template URI template, prompt name).
-- In JSON Schemas, `enum` and `required` arrays are treated as sets (order-insensitive).
-- In server manifests (`://mcp/manifest`), per-tool `operations` lists are treated as sets (order-insensitive).
-- Schema combinators like `oneOf` / `anyOf` / `allOf` preserve order.
-
-If all identity-bearing sections are inspected successfully, the snapshot includes `surfaceDigest` (`sha256:...`).
-
-If any identity-bearing section cannot be inspected, the snapshot is marked `surfaceCompleteness: "partial"` and no `surfaceDigest` is emitted.
-
-Tool, resource, resource-template, and prompt descriptions participate in surface identity. Preflight-generated risk labels, signals, timestamps, commands, notes, and errors do not.
-
-`protocolVersion` is preserved in `observation` but does not participate in `surfaceDigest`.
-
-The digest identifies the normalized declaration observed when all identity-bearing inspection sections completed successfully. It does not verify that the server’s declaration is truthful, exhaustive, safe, or representative of runtime behavior.
-
-### Exit codes
-
-`mcp-preflight` is designed to be usable in CI. It returns a nonzero exit code when it cannot produce a complete, comparable surface identity.
-
-#### `mcp-preflight` (inspect)
-
-- **0**: inspection succeeded and `observation.status == "ok"` (a complete surface identity was emitted)
-- **1**: inspection was partial or failed (`observation.status != "ok"`) but a snapshot may still be written via `--save` and/or printed via `--json`
-
-Examples of non-`ok` statuses include: `partial`, `timeout`, `auth_gated`, `auth_required`, `startup_error`.
-
-#### `mcp-preflight diff`
-
-- **0**: diff completed successfully (regardless of whether changes were found)
-- **2**: user-facing error (for example, invalid JSON or unsupported snapshot format/version)
-
-`mcp-preflight diff` prints a human-readable diff. It does not currently signal “changed” vs “unchanged” via exit code; use the output text (or wait for `diff --json` / `check` workflow commands).
-
-### Legacy JSON reports
-
-`mcp-preflight diff` accepts older, unversioned legacy report JSON. Legacy reports are treated as **partial** and compared with explicit evidence/observability limitations:
-
-- Missing legacy evidence (for example, tool schemas not captured by the legacy format) is not rendered as a proven capability change.
-- Digest-based identity comparison is only available when both inputs are complete snapshots.
-
-When legacy/partial inputs are involved, diffs may include:
-
-- `Complete-surface identity comparison: unavailable`
-- `Comparison limitations: ...`
-- `Newly observable:` / `Newly unobservable:` (for fields that became observable due to improved snapshot evidence capture)
+</details>
 
 <details>
 <summary>Auth-gated servers / custom env</summary>
@@ -215,23 +179,11 @@ mcp-preflight --isolate-home "npx -y my-mcp-server"
 </details>
 
 <details>
-<summary>Risk classification heuristic</summary>
+<summary>Optional heuristic annotations</summary>
 
-Based on tool names and descriptions (conservative by default):
+Interactive inspection can add heuristic signals, including read/write/destructive annotations, based on tool names and descriptions. These are hints only: they are not enforced and do not participate in the surface digest.
 
-- 🟢 **read-only**: `get`, `list`, `search`, `read`, `fetch`, `find`, `show`, `view`
-- 🟡 **write**: `create`, `add`, `update`, `set`, `send`, `write`, `upload`
-- 🔴 **destructive**: `delete`, `remove`, `destroy`, `drop`, `purge`, `clear`, `reset`
-- Unknown → 🟡 (assume write until proven otherwise)
-
-</details>
-
-<details>
-<summary>Signals (heuristic)</summary>
-
-`mcp-preflight` can emit “signals” based on text matching (best-effort). These are hints, not guarantees, and may have false positives/negatives.
-
-Disable with:
+Disable them with:
 
 ```bash
 mcp-preflight --no-signals "uv run server.py"
@@ -241,18 +193,17 @@ mcp-preflight --no-signals "uv run server.py"
 
 ## Non-goals
 
-- No sandboxing
-- No policy enforcement
-- No runtime analysis
+`mcp-preflight` does not provide sandboxing, policy enforcement, or runtime analysis. It describes the interface a server declares; it does not prove that declaration is truthful, exhaustive, or safe.
 
-This tool inspects the declared interface presented by the server. It does not call tools (`call_tool`).
+## Documentation
 
-It may read declared resources (for example, a server manifest) via `read_resource`. From the client’s perspective that is a read-oriented operation, but **servers can execute arbitrary code on any request**, including resource reads. Preflight is visibility, not a safety guarantee.
-
-## Principles
-See [PRINCIPLES.md](PRINCIPLES.md).
+- Snapshots: see [docs/snapshots.md](docs/snapshots.md)
+- Server manifests (optional): see [docs/server-manifest.md](docs/server-manifest.md)
+- Design principles: see [PRINCIPLES.md](PRINCIPLES.md)
+- Deeper framing/experiments: see [You can’t prove an MCP server hasn’t changed](You%20can%E2%80%99t%20prove%20an%20MCP%20server%20hasn%E2%80%99t%20changed.md)
 
 
 ## Project
 
 - Bugs / feature requests: [GitHub Issues](https://github.com/jordanstarrk/mcp-preflight/issues)
+- License: [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@
 `ls -la` for MCP servers. Inspect what a server declares before giving it operational access.
 `mcp-preflight` captures a server’s declared tools, schemas, resources, templates, prompts, and additional declared operations. It can save that surface as a deterministic snapshot, assign complete observations a stable SHA-256 identity, and show structural changes over time.
 
+## TL;DR
+
+- **Inspect**: show the client-visible MCP surface (tools, schemas, resources/templates, prompts).
+- **Snapshot**: `--save` / `--json` emit a versioned snapshot JSON you can commit.
+- **Fingerprint**: complete snapshots get a deterministic `surfaceDigest` (sha256 of the canonical surface).
+- **Diff**: `mcp-preflight diff` reports structural capability changes (not just tool-count changes).
+- **Evidence-aware comparisons**: legacy/partial inputs don’t support complete identity claims; limitations and evidence gaps are rendered explicitly.
+- **Manifest support**: can read `{scheme}://mcp/manifest` to surface multiplexed per-tool operations.
+
 
 
 ## Install
@@ -73,6 +82,23 @@ mcp-preflight diff before.json after.json
 mcp-preflight --json "uv run server.py"
 ```
 
+### CI-friendly usage (snapshot + diff)
+
+```bash
+# Create and commit a baseline snapshot (one-time)
+mcp-preflight --save mcp-surface.json "uv run server.py"
+git add mcp-surface.json
+
+# Later (e.g. after an upgrade): re-inspect and diff
+mcp-preflight --save mcp-surface-current.json "uv run server.py" || true
+mcp-preflight diff mcp-surface.json mcp-surface-current.json
+```
+
+Notes:
+
+- `mcp-preflight` exits **nonzero** when inspection is partial/failed, but it can still save a snapshot; `|| true` lets a CI job continue to run `diff`.
+- `mcp-preflight diff` currently prints a human diff and does not return “changed vs unchanged” via exit code.
+
 ## What changes can it detect?
 
 Snapshots can reveal changes that do not alter a tool name, including:
@@ -91,7 +117,7 @@ Snapshots can reveal changes that do not alter a tool name, including:
 
 ## Snapshot JSON format
 
-`--json` and `--save` emit a **versioned snapshot**. Note: v0.2 replaces the previous report JSON format with this versioned snapshot format.
+`--json` and `--save` emit a **versioned snapshot**. (Older `mcp-preflight` versions emitted an unversioned “report” JSON format; snapshots are the stable format going forward.)
 
 - **`observation`**: timestamp, command, negotiated protocol version, inspection status, coverage, notes, errors, and local heuristic annotations.
 - **`surface`**: the server-declared tools, descriptions, the complete `inputSchema` returned by the server, resources, resource templates, prompts, prompt arguments, and additional declaration sources.
@@ -114,6 +140,37 @@ Tool, resource, resource-template, and prompt descriptions participate in surfac
 `protocolVersion` is preserved in `observation` but does not participate in `surfaceDigest`.
 
 The digest identifies the normalized declaration observed when all identity-bearing inspection sections completed successfully. It does not verify that the server’s declaration is truthful, exhaustive, safe, or representative of runtime behavior.
+
+### Exit codes
+
+`mcp-preflight` is designed to be usable in CI. It returns a nonzero exit code when it cannot produce a complete, comparable surface identity.
+
+#### `mcp-preflight` (inspect)
+
+- **0**: inspection succeeded and `observation.status == "ok"` (a complete surface identity was emitted)
+- **1**: inspection was partial or failed (`observation.status != "ok"`) but a snapshot may still be written via `--save` and/or printed via `--json`
+
+Examples of non-`ok` statuses include: `partial`, `timeout`, `auth_gated`, `auth_required`, `startup_error`.
+
+#### `mcp-preflight diff`
+
+- **0**: diff completed successfully (regardless of whether changes were found)
+- **2**: user-facing error (for example, invalid JSON or unsupported snapshot format/version)
+
+`mcp-preflight diff` prints a human-readable diff. It does not currently signal “changed” vs “unchanged” via exit code; use the output text (or wait for `diff --json` / `check` workflow commands).
+
+### Legacy JSON reports
+
+`mcp-preflight diff` accepts older, unversioned legacy report JSON. Legacy reports are treated as **partial** and compared with explicit evidence/observability limitations:
+
+- Missing legacy evidence (for example, tool schemas not captured by the legacy format) is not rendered as a proven capability change.
+- Digest-based identity comparison is only available when both inputs are complete snapshots.
+
+When legacy/partial inputs are involved, diffs may include:
+
+- `Complete-surface identity comparison: unavailable`
+- `Comparison limitations: ...`
+- `Newly observable:` / `Newly unobservable:` (for fields that became observable due to improved snapshot evidence capture)
 
 <details>
 <summary>Auth-gated servers / custom env</summary>

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 [![Downloads](https://static.pepy.tech/badge/mcp-preflight)](https://pepy.tech/project/mcp-preflight)
 [![PyPI version](https://img.shields.io/pypi/v/mcp-preflight.svg)](https://pypi.org/project/mcp-preflight/)
 
-`ls -la` for MCP servers. See what an MCP server exposes before you connect it.
-
-Agent systems often fail due to surprising defaults and invisible capability surfaces. `mcp-preflight` exists to make those visible before trust is established.
+`ls -la` for MCP servers. Inspect what a server declares before giving it operational access.
+`mcp-preflight` captures a server’s declared tools, schemas, resources, templates, prompts, and additional declared operations. It can save that surface as a deterministic snapshot, assign complete observations a stable SHA-256 identity, and show structural changes over time.
 
 
 
@@ -39,9 +38,9 @@ my-server (MCP 2025-03-26)
     📄 my-server://items
     📄 my-server://items/{id}
 
-  Action-level Capabilities (server-declared, 12 operations across 3 tools):
-    Not directly visible via MCP introspection.
-    These represent additional actions exposed behind the tools above.
+  Additional declared operations (from server manifest, 12 across 3 tools):
+    Not represented as separate entries in tools/list.
+    These are server-declared actions multiplexed behind the tools above.
       ↳ items (8): list, get, create, update, delete, search, export, archive
       ↳ reports (3): daily, weekly, monthly
       ↳ auth_login (single action)
@@ -64,30 +63,67 @@ mcp-preflight "uv run server.py"
 mcp-preflight "npx my-mcp-server"
 mcp-preflight "python3 /path/to/server.py"
 
-# Save a report (JSON)
-mcp-preflight --save report.json "uv run server.py"
+# Save a snapshot (JSON)
+mcp-preflight --save snapshot.json "uv run server.py"
 
-# Diff two saved reports
+# Diff two saved snapshots
 mcp-preflight diff before.json after.json
 
 # JSON output
 mcp-preflight --json "uv run server.py"
 ```
 
+## What changes can it detect?
+
+Snapshots can reveal changes that do not alter a tool name, including:
+
+- input fields added or removed
+- enum actions added behind an existing tool
+- required parameters changing
+- descriptions changing
+- resources, templates, prompts, or prompt arguments changing
+
 ## Notes
 
-- Runs the server locally in inspection mode (no tools are executed).
-- Lists exposed MCP tools, resources, and prompts.
+- Starts the server locally and performs MCP discovery without invoking the server’s declared tools.
+- Lists the declared tools, descriptions, input schemas, resources, resource templates, prompts, and prompt arguments returned by the server.
 - If a single tool supports multiple actions, publish a `{scheme}://mcp/manifest` resource so preflight can surface and diff them. See [server manifest docs](docs/server-manifest.md).
+
+## Snapshot JSON format
+
+`--json` and `--save` emit a **versioned snapshot**. Note: v0.2 replaces the previous report JSON format with this versioned snapshot format.
+
+- **`observation`**: timestamp, command, negotiated protocol version, inspection status, coverage, notes, errors, and local heuristic annotations.
+- **`surface`**: the server-declared tools, descriptions, the complete `inputSchema` returned by the server, resources, resource templates, prompts, prompt arguments, and additional declaration sources.
+
+Only `surface` is deterministically normalized and hashed.
+
+Normalization rules (high level):
+
+- Lists are sorted by identity keys (tool name, resource URI, template URI template, prompt name).
+- In JSON Schemas, `enum` and `required` arrays are treated as sets (order-insensitive).
+- In server manifests (`://mcp/manifest`), per-tool `operations` lists are treated as sets (order-insensitive).
+- Schema combinators like `oneOf` / `anyOf` / `allOf` preserve order.
+
+If all identity-bearing sections are inspected successfully, the snapshot includes `surfaceDigest` (`sha256:...`).
+
+If any identity-bearing section cannot be inspected, the snapshot is marked `surfaceCompleteness: "partial"` and no `surfaceDigest` is emitted.
+
+Tool, resource, resource-template, and prompt descriptions participate in surface identity. Preflight-generated risk labels, signals, timestamps, commands, notes, and errors do not.
+
+`protocolVersion` is preserved in `observation` but does not participate in `surfaceDigest`.
+
+The digest identifies the normalized declaration observed when all identity-bearing inspection sections completed successfully. It does not verify that the server’s declaration is truthful, exhaustive, safe, or representative of runtime behavior.
 
 <details>
 <summary>Auth-gated servers / custom env</summary>
 
-Some MCP servers only reveal tools/resources after authentication. `mcp-preflight` does not run login flows, so it may report capabilities as not enumerable until credentials are provided.
+Some MCP servers only reveal tools/resources after authentication. `mcp-preflight` does not run login flows, so it may be unable to enumerate some or all of the declared surface until credentials are provided.
 
 ```bash
 # Pass a token via env
-mcp-preflight --env MCP_SERVER_TOKEN=... "npx -y my-mcp-server"
+export MCP_SERVER_TOKEN=...
+mcp-preflight "npx -y my-mcp-server"
 
 # Point HOME (and XDG_* dirs) somewhere else (useful for servers that read ~/.config, ~/.local, etc.)
 mcp-preflight --home /tmp/mcp-preflight-home "npx -y my-mcp-server"
@@ -129,7 +165,9 @@ mcp-preflight --no-signals "uv run server.py"
 - No policy enforcement
 - No runtime analysis
 
-This tool inspects exposed MCP capabilities. It does not call tools (`call_tool`). Manifest data is read via `read_resource` — no server state is mutated.
+This tool inspects the declared interface presented by the server. It does not call tools (`call_tool`).
+
+It may read declared resources (for example, a server manifest) via `read_resource`. From the client’s perspective that is a read-oriented operation, but **servers can execute arbitrary code on any request**, including resource reads. Preflight is visibility, not a safety guarantee.
 
 ## Principles
 See [PRINCIPLES.md](PRINCIPLES.md).
@@ -137,4 +175,4 @@ See [PRINCIPLES.md](PRINCIPLES.md).
 
 ## Project
 
-- Bugs / feature requests: [GitHub Issues](`https://github.com/jordanstarrk/mcp-preflight/issues`)
+- Bugs / feature requests: [GitHub Issues](https://github.com/jordanstarrk/mcp-preflight/issues)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,29 @@ Notes:
 - `mcp-preflight` exits **nonzero** when inspection is partial/failed, but it can still save a snapshot; `|| true` lets a CI job continue to run `diff`.
 - `mcp-preflight diff` currently prints a human diff and does not return “changed vs unchanged” via exit code.
 
+### CI gate: `mcp-preflight check`
+
+For pull-request gating, use `check` (a single command with stable exit codes):
+
+```bash
+# Create and commit a baseline snapshot (one-time)
+mcp-preflight --save mcp-surface.json "uv run server.py"
+git add mcp-surface.json
+
+# In CI / pull requests
+mcp-preflight check mcp-surface.json "uv run server.py"
+```
+
+Exit codes:
+
+- **0**: unchanged (complete identity comparable; `surfaceDigest` matches)
+- **1**: changed (complete identity comparable; `surfaceDigest` differs)
+- **2**: inspection failed (timeout, auth required, startup error, etc.)
+- **3**: inspection partial / identity incomparable
+- **4**: invalid baseline (missing/partial snapshot, unsupported snapshot version, invalid JSON)
+
+`check --json` prints a machine-readable result (suitable for CI bots and wrappers).
+
 ## What changes can it detect?
 
 Snapshots can reveal changes that do not alter a tool name, including:

--- a/You can’t prove an MCP server hasn’t changed.md
+++ b/You can’t prove an MCP server hasn’t changed.md
@@ -1,0 +1,119 @@
+Date: Feb 26, 2026
+
+## Why this doc exists
+
+This document exists to help me map the MCP inspection space and clarify where [mcp-preflight](https://github.com/jordanstarrk/mcp-preflight) should (and should not) evolve.
+
+MCP makes it easy to connect agents to tools, but it does not provide a durable way to reason about how a server’s declared capabilities change over time. While exploring this, I ran a set of small, controlled experiments to understand what the protocol exposes today, what declaration frameworks improve, and what remains missing.
+
+The goal here is not to propose policy, enforcement, or runtime controls.
+
+It’s to identify whether there is a missing inspection primitive in the MCP ecosystem, and if so, what shape it should have.
+
+### 1\. The problem
+
+MCP exposes a server’s current declared surface, but does not itself define durable history, stable snapshot identity, or structural comparison across points in time. It tells you what a server *declares* it can do at the time of inspection, but it has no memory of what it could do yesterday, last week, or last month.
+
+As a result, today’s ecosystem answers questions about current state and execution, but leaves a set of inspection questions unanswered:
+
+* What did the server declare last time?  
+* What does it declare now?  
+* What specifically changed?  
+* Can I produce durable evidence of what changed between two declared surfaces?
+
+This is not about safety or enforcement; it’s about losing memory. 
+
+While individuals can try to track this manually, there’s no shared or protocol-native way to treat a *declared capability surface* as a stable, versioned object over time.
+
+### 2\. The landscape: 5 dimensions of MCP systems
+
+To articulate this gap, we have to distinguish between different questions. Solving one does not solve the others.
+
+| Layer | Questions it answers | Current tooling | Notes |
+| :---- | :---- | :---- | :---- |
+| **Declaration** | What capabilities exist? How are actions structured?What’s behind a tool’s name?  | MCP protocol, Declaration frameworks (mcp-fusion) | Declaration frameworks significantly improve the clarity and structure of declared surface, but do not provide durability or   continuity over time.  |
+| **Inspection** | What changed since last time?Is the surface durable over time? | **\[THE GAP\]** | No protocol-native snapshot, diff, or stable surface identity. |
+| **Governance** | Is this surface approved? | Registries, approval workflows | Approval is typically one-time or version-based, not tied to a stable declared surface snapshot.  |
+| **Runtime** | Is this specific call allowed? | Gateways, Mcp-use, Cursor, other clients/execution controls? | Controls execution at call time; consumes current state but does not reason about past vs present surfaces. |
+| **Observability**  | What happened / why? | Logs, traces, audit events | Describes executed behavior after the fact, not declared capability surfaces. |
+
+Each layer answers a different question.
+
+### 3\. What the experiments imply about inspection
+
+Across vanilla MCP and MCP Fusion, the experiments show the same pattern:
+
+| Mutation type | MCP Core Protocol | Declaration Frameworks (mcp-fusion) | Still missing |
+| ----- | ----- | ----- | ----- |
+| Add tool at runtime | ❌ | ✅ (manifest) | Durable snapshot / diff |
+| Expand schema under same tool | ❌ | ✅ (manifest) | Continuity proof |
+| Expand consolidated action enum | ❌ | ✅ (manifest) | Reviewer-visible diff |
+| Behavior drift (no declaration change) | ❌ | ❌ | Out of scope |
+| Restart / context change | ❌ | ❌ | Surface identity |
+
+**Evidence (reproducible experiments)** https://github.com/jordanstarrk/mcp-visibility-gap-demo
+
+MCP Fusion makes declared capability surfaces more explicit and machine-readable, but does not make them durable over time.
+
+### 4\. Who cares?
+
+This gap does not matter for every use case. It becomes critical in environments where trust but verify is the standard:
+
+* **Dependency installation** You didn’t write the server, you upgraded a package. Did capabilities quietly expand?
+
+* **Shared agent setups** One server powers multiple agents or teams. A change declaration affects everyone simultaneously.
+
+* **Regulated or audited environments (e.g. EU AI Act)** When systems require traceability of capabilities and change control over time, one-time approval of a live-declared surface is insufficient.
+
+* **Teams using richer declaration frameworks** (e.g. MCP Fusion). As capability surfaces become more expressive and legible, it becomes more important to know whether that surface has changed since it was last reviewed. 
+
+
+### 5\. Definitions: ‘declared surface’
+
+### 
+
+### **Declared surface**
+
+### Anything MCP introspection exposes that describes what a server says it can do: tool names, descriptions, schemas, actions, resources, prompts.
+
+In practice, this surface may be exposed via:
+
+* tools/list  
+* resources/read (e.g. dynamic manifests)  
+* framework-specific introspection
+
+**Declared surface fingerprint (proposed)**  
+A hash or signed snapshot of the surface at a point in time. This is informational, not authoritative. A way to reference and compare surfaces, not to enforce trust. 
+
+**Clarifications:**
+
+* This is not runtime behavior  
+* This is not what actually executed  
+* This is what the server declares it can do
+
+###  6\. Inspection requirements (minimal)
+
+From these experiments, an inspection layer must be able to:
+
+1. **Snapshot declared surfaces.** Capture what a server declares at time T, not just query live state.  
+2. **Diff surfaces structurally.** Detect tool additions, schema expansion, and action-level changes — even under the same tool name.  
+3. **Reference declaration sources.** Treat tools/list, resources/read (manifests), and framework introspection as a single surface.  
+4. **Record inspection context.** Auth state, startup configuration, and environment affect what is declared.  
+5. **Detect surface mutability.** Distinguish stable surfaces from runtime-mutating ones.
+
+These are inspection properties, not enforcement, policy, or runtime control. 
+
+### 7\. The gap → governance tools are missing an MCP primitive
+
+The gap is declared surface identity, history, and change visibility
+
+Even with rich, protocol-native manifests, governance systems lack a stable object they can reference over time. Once time has passed, they cannot reliably determine whether a previously reviewed declared surface is still the same.
+
+Inspection is the mechanism that turns declaration into something governance can reason about. Without a durable notion of “declared surface at time T”, governance systems have nothing stable to anchor approval or re-review decisions.
+
+Current MCP governance efforts help, but do not close this gap:
+
+* inventory ≠ capability diff  
+* runtime ≠ declared surface history  
+* version pinning ≠ schema-level expansion  
+* CI scans ≠ protocol-native declaration tracking

--- a/docs/server-manifest.md
+++ b/docs/server-manifest.md
@@ -7,7 +7,7 @@ If your server exposes a **manifest resource**, mcp-preflight can surface and di
 
 ## What to do
 
-Expose a **read-only MCP resource** at:
+Expose a **read-oriented MCP resource** at:
 
 ```
 {your-scheme}://mcp/manifest
@@ -59,7 +59,7 @@ Because it’s generated from the same source as your tools:
 
 ## Design principles
 
-- **Read-only**: this is introspection, not execution
+- **Read-oriented**: this is introspection, not execution (servers may still run arbitrary code to service any request)
 - **Declared, not inferred**: the server reports what exists
 - **Lens, not a judge**: no risk scoring or policy decisions
 - **Optional**: servers without a manifest still work fine

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -1,0 +1,39 @@
+# Snapshot format and normalization
+
+`mcp-preflight` emits a **versioned snapshot JSON** via `--json` and `--save`.
+
+At a high level:
+
+- **`observation`**: timestamp, command, negotiated protocol version, inspection status/coverage, notes, and errors.
+- **`surface`**: the declared tools + schemas, resources/templates, prompts/prompt arguments, and additional declaration sources.
+
+Only `surface` is deterministically normalized and hashed.
+
+## Surface digest (`surfaceDigest`)
+
+If every supported, identity-bearing discovery section completes successfully, the snapshot includes a `surfaceDigest` (`sha256:...`).
+
+If any identity-bearing section is incomplete, the snapshot is marked `surfaceCompleteness: "partial"` and **no digest is emitted**. This avoids claiming a comparable surface identity when inspection was incomplete.
+
+The digest identifies the normalized declaration observed under a defined inspection model. It does not verify that the server’s declaration is truthful, exhaustive, safe, or representative of runtime behavior.
+
+## Normalization rules (high level)
+
+- Lists are sorted by identity keys (tool name, resource URI, template URI template, prompt name).
+- In JSON Schemas, `enum` and `required` arrays are treated as sets (order-insensitive).
+- In server manifests (`://mcp/manifest`), per-tool `operations` lists are treated as sets (order-insensitive).
+- Schema combinators like `oneOf` / `anyOf` / `allOf` preserve order.
+
+## What participates in identity?
+
+Tool, resource, resource-template, and prompt descriptions participate in surface identity.
+
+Preflight-generated heuristic annotations, timestamps, commands, notes, and errors do not.
+
+## Legacy JSON inputs
+
+`mcp-preflight diff` accepts older, unversioned legacy report JSON. Legacy reports are treated as **partial**:
+
+- Missing legacy evidence is not rendered as a proven capability change.
+- Digest-based identity comparison is only available when both inputs are complete snapshots.
+

--- a/mcp_preflight.py
+++ b/mcp_preflight.py
@@ -527,6 +527,14 @@ def print_text_report(snapshot: dict) -> None:
         print("  Status: ⚠️  partial\n")
         _print_introspection_coverage(snapshot)
 
+    # Surface identity: show the digest when available.
+    completeness = str(snapshot.get("surfaceCompleteness") or "partial")
+    digest = snapshot.get("surfaceDigest")
+    if digest and completeness == "complete":
+        print(f"  Surface digest: {digest}\n")
+    elif status == "partial":
+        print("  Surface digest: unavailable (partial inspection)\n")
+
     local = obs.get("localAnnotations") or {}
     print_tools(local.get("tools", []))
 
@@ -2144,6 +2152,7 @@ def diff_reports(before: dict, after: dict) -> str:
     else:
         lines.append("")
         # No digest comparison shown unless both snapshots are complete; see identityComparable below.
+    summary_insert_at = len(lines)
 
     comparison = _compute_snapshot_comparison(b, a)
     identity_comparable = bool(comparison.get("identityComparable"))
@@ -2552,6 +2561,9 @@ def diff_reports(before: dict, after: dict) -> str:
 
     # If nothing changed beyond header.
     has_change_sections = any(h in lines for h in ("  Tools:", "  Resources:", "  Prompts:", "  Capabilities (manifest-declared):"))
+    if identity_comparable and has_change_sections:
+        lines.insert(summary_insert_at, "  Surface changed.")
+        lines.insert(summary_insert_at + 1, "")
     if not has_change_sections:
         if identity_comparable:
             lines.append("  No changes detected.\n")
@@ -2813,7 +2825,13 @@ def main() -> None:
 
         # Load and validate baseline.
         try:
-            baseline_raw = json.loads(ns.baseline.read_text(encoding="utf-8"))
+            baseline_text = ns.baseline.read_text(encoding="utf-8")
+        except OSError as e:
+            sys.stderr.write(f"mcp-preflight check: error: could not read baseline ({e})\n")
+            raise SystemExit(4)
+
+        try:
+            baseline_raw = json.loads(baseline_text)
         except json.JSONDecodeError as e:
             sys.stderr.write(f"mcp-preflight check: error: invalid baseline JSON ({e})\n")
             raise SystemExit(4)

--- a/mcp_preflight.py
+++ b/mcp_preflight.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import json
 import os
 import re
@@ -74,11 +75,48 @@ def classify_tool(name: str, description: str) -> tuple[str, str]:
 def _normalize_text(s: object) -> str:
     return " ".join(str(s).split())
 
+def _normalize_declared_text(value: str | None) -> str | None:
+    """Normalize declared text without semantic whitespace rewriting."""
+    if value is None:
+        return None
+    return value.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _json_safe(v: Any) -> Any:
+    """Best-effort conversion of a value into JSON-safe primitives (observation only)."""
+    if v is None or isinstance(v, (str, int, float, bool)):
+        return v
+    if isinstance(v, dict):
+        return {str(k): _json_safe(val) for k, val in v.items()}
+    if isinstance(v, (list, tuple)):
+        return [_json_safe(x) for x in v]
+    return _normalize_text(v)
+
+def _json_identity(v: Any) -> Any:
+    """Strict JSON conversion for identity-bearing surface fields."""
+    if v is None or isinstance(v, (str, int, float, bool)):
+        return v
+    if isinstance(v, dict):
+        return {str(k): _json_identity(val) for k, val in v.items()}
+    if isinstance(v, (list, tuple)):
+        return [_json_identity(x) for x in v]
+    raise TypeError(f"Non-JSON identity value: {type(v).__name__}")
+
 
 def _tool_dict(tool: Any) -> dict:
     desc = tool.description or "(no description)"
     icon, risk = classify_tool(tool.name, desc)
     return {"name": tool.name, "description": _normalize_text(desc), "risk": risk, "icon": icon}
+
+def _tool_surface_dict(tool: Any) -> dict:
+    """Tool entry for the hashed declared surface."""
+    desc = getattr(tool, "description", None)
+    schema = getattr(tool, "inputSchema", None)
+    return {
+        "name": tool.name,
+        "description": _normalize_declared_text(desc) if isinstance(desc, str) else None,
+        "inputSchema": _json_identity(schema) if schema is not None else None,
+    }
 
 
 def _prompt_dict(prompt: Any) -> dict:
@@ -90,6 +128,57 @@ def _prompt_dict(prompt: Any) -> dict:
         "name": prompt.name,
         "arguments": args,
         "description": _normalize_text(desc) if desc else None,
+    }
+
+def _prompt_surface_dict(prompt: Any) -> dict:
+    """Prompt entry for the hashed declared surface."""
+    desc = getattr(prompt, "description", None)
+    args: list[dict] = []
+    raw_args = getattr(prompt, "arguments", None)
+    if raw_args:
+        for a in raw_args:
+            entry: dict[str, Any] = {"name": getattr(a, "name", None)}
+            a_desc = getattr(a, "description", None)
+            if isinstance(a_desc, str):
+                entry["description"] = _normalize_declared_text(a_desc)
+            if hasattr(a, "required"):
+                req = getattr(a, "required")
+                if isinstance(req, bool):
+                    entry["required"] = req
+            # Some implementations expose a schema-like dict; include only if it's JSON-safe.
+            a_schema = getattr(a, "schema", None)
+            if isinstance(a_schema, dict):
+                entry["schema"] = _json_identity(a_schema)
+            args.append(entry)
+    args.sort(key=lambda x: x.get("name") or "")
+    return {
+        "name": prompt.name,
+        "arguments": args,
+        "description": _normalize_declared_text(desc) if isinstance(desc, str) else None,
+    }
+
+
+def _resource_surface_dict(resource: Any) -> dict:
+    ann = getattr(resource, "annotations", None)
+    return {
+        "uri": str(getattr(resource, "uri", "")),
+        "name": getattr(resource, "name", None),
+        "title": getattr(resource, "title", None),
+        "description": _normalize_declared_text(getattr(resource, "description", None)),
+        "mimeType": getattr(resource, "mimeType", None),
+        "annotations": _json_identity(ann) if ann is not None else None,
+    }
+
+
+def _resource_template_surface_dict(tpl: Any) -> dict:
+    ann = getattr(tpl, "annotations", None)
+    return {
+        "uriTemplate": str(getattr(tpl, "uriTemplate", "")),
+        "name": getattr(tpl, "name", None),
+        "title": getattr(tpl, "title", None),
+        "description": _normalize_declared_text(getattr(tpl, "description", None)),
+        "mimeType": getattr(tpl, "mimeType", None),
+        "annotations": _json_identity(ann) if ann is not None else None,
     }
 
 
@@ -142,6 +231,23 @@ def _expand_tool_capabilities(caps_data: dict) -> list[dict]:
         items.append(entry)
     items.sort(key=lambda e: e["tool"])
     return items
+
+
+def _find_list_duplicates(values: list[Any]) -> list[Any]:
+    """Return a stable list of duplicate values (by JSON identity when possible)."""
+    seen: set[str] = set()
+    dupes: dict[str, Any] = {}
+    for v in values:
+        try:
+            key = json.dumps(v, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False)
+        except Exception:
+            key = _normalize_text(v)
+        if key in seen and key not in dupes:
+            dupes[key] = v
+        else:
+            seen.add(key)
+    # Stable output order.
+    return [dupes[k] for k in sorted(dupes.keys())]
 
 
 SUSPICIOUS_PATTERNS: list[tuple[str, re.Pattern]] = [
@@ -263,9 +369,9 @@ def print_tool_capabilities(tool_caps: list[dict]) -> None:
 
     ops_word = "operation" if total_ops == 1 else "operations"
     tools_word = "tool" if len(tool_caps) == 1 else "tools"
-    print(f"  Action-level Capabilities (server-declared, {total_ops} {ops_word} across {len(tool_caps)} {tools_word}):")
-    print("    Not directly visible via MCP introspection.")
-    print("    These represent additional actions exposed behind the tools above.")
+    print(f"  Additional declared operations (from server manifest, {total_ops} {ops_word} across {len(tool_caps)} {tools_word}):")
+    print("    Not represented as separate entries in tools/list.")
+    print("    These are server-declared actions multiplexed behind the tools above.")
     for entry in tool_caps:
         name = entry["tool"]
         ops = entry.get("operations")
@@ -290,7 +396,12 @@ def print_prompts(prompts: list[dict], *, supported: bool = True, had_error: boo
     for p in sorted(prompts, key=lambda x: x.get("name", "")):
         args = ""
         if p.get("arguments"):
-            arg_names = p["arguments"]
+            raw_args = p["arguments"]
+            # Supports both legacy ["a","b"] args and surface [{"name":"a"},...] args.
+            if raw_args and isinstance(raw_args[0], dict):
+                arg_names = [a.get("name") for a in raw_args if isinstance(a, dict) and a.get("name")]
+            else:
+                arg_names = raw_args
             args = f" ({', '.join(arg_names)})"
         print(f"    💬 {p['name']}{args}")
     print()
@@ -350,54 +461,59 @@ def print_risk_summary(counts: dict) -> None:
     print()
 
 
-def _print_introspection_coverage(report: dict) -> None:
-    """Print a ✓/✗ checklist showing which MCP introspection calls succeeded.
+def _print_introspection_coverage(snapshot: dict) -> None:
+    """Print a ✓/✗ checklist showing which introspection calls succeeded."""
+    obs = snapshot.get("observation") or {}
+    cov = obs.get("coverage") or {}
 
-    Only meaningful for partial reports — shows what was attempted and whether
-    it succeeded so the reader can tell at a glance what's missing.
-    """
-    capabilities = report.get("capabilities", {})
-    notes = report.get("notes", [])
-    errors = report.get("errors", [])
-
-    # Build a map of failed MCP calls: name → rule (timeout/error).
-    failed: dict[str, str] = {}
-    for n in notes + errors:
-        if n.get("kind") == "mcp" and n.get("rule") in ("timeout", "error"):
-            failed[n["name"]] = n["rule"]
+    def fmt_section(name: str, key: str) -> str | None:
+        s = cov.get(key) or {}
+        if not isinstance(s, dict):
+            return None
+        attempted = bool(s.get("attempted"))
+        completed = bool(s.get("completed"))
+        declared = s.get("declaredSupported")
+        if declared is False and not attempted:
+            return None
+        if not attempted:
+            return f"    - {name} (not attempted)"
+        if completed:
+            return f"    ✓ {name}"
+        rule = s.get("errorRule") or "error"
+        return f"    ✗ {name} ({rule})"
 
     print("  Introspection coverage:")
-
-    # Tools — always attempted (many servers omit the capability flag).
-    if "list_tools" in failed:
-        print(f"    ✗ tools ({failed['list_tools']})")
-    else:
-        print("    ✓ tools")
-
-    # Resources — only attempted when the server declares the capability.
-    if capabilities.get("resources"):
-        res_fail = failed.get("list_resources") or failed.get("list_resource_templates")
-        if res_fail:
-            print(f"    ✗ resources ({res_fail})")
-        else:
-            print("    ✓ resources")
-
-    # Prompts — only attempted when the server declares the capability.
-    if capabilities.get("prompts"):
-        if "list_prompts" in failed:
-            print(f"    ✗ prompts ({failed['list_prompts']})")
-        else:
-            print("    ✓ prompts")
-
+    for label, key in (
+        ("tools", "tools"),
+        ("resources", "resources"),
+        ("resource templates", "resourceTemplates"),
+        ("prompts", "prompts"),
+        ("manifest", "manifest"),
+    ):
+        line = fmt_section(label, key)
+        if line:
+            print(line)
     print()
 
 
-def print_text_report(report: dict) -> None:
-    """Render a finalized report dict as human-readable text to stdout."""
-    server = report.get("server", {})
-    status = report.get("status", "ok")
+def _manifest_tool_caps_from_surface(surface: dict) -> list[dict]:
+    for src in surface.get("declarationSources") or []:
+        if isinstance(src, dict) and src.get("name") == "mcp_manifest":
+            extracted = src.get("extracted") or {}
+            if isinstance(extracted, dict) and isinstance(extracted.get("toolCapabilities"), list):
+                return extracted["toolCapabilities"]
+    return []
 
-    print_header(server.get("name", "unknown"), server.get("protocolVersion", "unknown"))
+
+def print_text_report(snapshot: dict) -> None:
+    """Render a finalized snapshot dict as human-readable text to stdout."""
+    obs = snapshot.get("observation") or {}
+    surface = snapshot.get("surface") or {}
+    server_name = obs.get("serverName") or "unknown"
+    protocol_version = obs.get("protocolVersion") or "unknown"
+    status = obs.get("status", "ok")
+
+    print_header(server_name, protocol_version)
     print("  Caution: the server process runs locally without sandboxing.")
     print("  Use --isolate-home to prevent access to your real HOME directory.\n")
 
@@ -407,32 +523,32 @@ def print_text_report(report: dict) -> None:
 
     if status == "partial":
         print("  Status: ⚠️  partial\n")
-        _print_introspection_coverage(report)
+        _print_introspection_coverage(snapshot)
 
-    print_tools(report.get("tools", []))
+    local = obs.get("localAnnotations") or {}
+    print_tools(local.get("tools", []))
 
-    capabilities = report.get("capabilities", {})
-    notes = report.get("notes", [])
-    resources_had_error = any(
-        n.get("name") in ("list_resources", "list_resource_templates") for n in notes
-    )
+    capabilities = obs.get("capabilities", {})
+    notes = obs.get("notes", [])
+    errors = obs.get("errors", [])
+    resources_had_error = any(n.get("name") in ("list_resources", "list_resource_templates") for n in notes)
     prompts_had_error = any(n.get("name") == "list_prompts" for n in notes)
 
     print_resources(
-        report.get("resources", []),
-        report.get("resourceTemplates", []),
+        [r.get("uri") for r in (surface.get("resources") or []) if isinstance(r, dict) and r.get("uri")],
+        [t.get("uriTemplate") for t in (surface.get("resourceTemplates") or []) if isinstance(t, dict) and t.get("uriTemplate")],
         supported=capabilities.get("resources", True),
         had_error=resources_had_error,
     )
-    print_tool_capabilities(report.get("manifest", []))
+    print_tool_capabilities(_manifest_tool_caps_from_surface(surface))
     print_prompts(
-        report.get("prompts", []),
+        surface.get("prompts", []),
         supported=capabilities.get("prompts", True),
         had_error=prompts_had_error,
     )
-    print_signals(report.get("signals", []))
+    print_signals(local.get("signals", []))
     print_notes(notes)
-    print_risk_summary(report.get("risk", {}))
+    print_risk_summary(local.get("risk", {}))
 
 
 # ── Main ─────────────────────────────────────────────────────
@@ -592,6 +708,310 @@ def _build_report(
     return report
 
 
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    # Deterministic JSON for hashing: no whitespace, UTF-8, stable key ordering (after canonicalization).
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _canonicalize_schema(schema: Any) -> Any:
+    """Normalize JSON Schema-ish objects for stable identity."""
+    if isinstance(schema, dict):
+        out: dict[str, Any] = {}
+        for k in sorted(schema.keys()):
+            v = schema[k]
+            if k in ("required", "enum") and isinstance(v, list):
+                # Treat as sets; sort deterministically.
+                try:
+                    out[k] = sorted(v)
+                except TypeError:
+                    out[k] = sorted((_normalize_text(x) for x in v))
+                continue
+            # Do not reorder oneOf/anyOf/allOf by default; ordering can matter for some tooling.
+            out[k] = _canonicalize_schema(v)
+        return out
+    if isinstance(schema, list):
+        return [_canonicalize_schema(x) for x in schema]
+    return schema
+
+
+def _canonicalize_surface(surface: dict) -> dict:
+    """Return a deterministically ordered/normalized surface object for hashing."""
+    tools = surface.get("tools") or []
+    resources = surface.get("resources") or []
+    templates = surface.get("resourceTemplates") or []
+    prompts = surface.get("prompts") or []
+    decl_sources = surface.get("declarationSources") or []
+
+    norm_tools: list[dict] = []
+    for t in tools:
+        if not isinstance(t, dict):
+            continue
+        entry = {
+            "name": t.get("name"),
+            "description": t.get("description"),
+            "inputSchema": _canonicalize_schema(t.get("inputSchema")),
+        }
+        norm_tools.append(entry)
+    norm_tools.sort(key=lambda x: x.get("name") or "")
+
+    norm_resources: list[dict] = []
+    for r in resources:
+        if not isinstance(r, dict):
+            norm_resources.append({"uri": r})
+            continue
+        norm_resources.append(
+            {
+                "uri": r.get("uri"),
+                "name": r.get("name"),
+                "title": r.get("title"),
+                "description": r.get("description"),
+                "mimeType": r.get("mimeType"),
+                "annotations": _canonicalize_schema(r.get("annotations")),
+            }
+        )
+    norm_resources.sort(key=lambda x: x.get("uri") or "")
+
+    norm_templates: list[dict] = []
+    for t in templates:
+        if not isinstance(t, dict):
+            norm_templates.append({"uriTemplate": t})
+            continue
+        norm_templates.append(
+            {
+                "uriTemplate": t.get("uriTemplate"),
+                "name": t.get("name"),
+                "title": t.get("title"),
+                "description": t.get("description"),
+                "mimeType": t.get("mimeType"),
+                "annotations": _canonicalize_schema(t.get("annotations")),
+            }
+        )
+    norm_templates.sort(key=lambda x: x.get("uriTemplate") or "")
+
+    norm_prompts: list[dict] = []
+    for p in prompts:
+        if not isinstance(p, dict):
+            continue
+        args = p.get("arguments") or []
+        norm_args: list[dict] = []
+        for a in args:
+            if not isinstance(a, dict):
+                continue
+            arg_entry: dict[str, Any] = {"name": a.get("name")}
+            if a.get("description") is not None:
+                arg_entry["description"] = a.get("description")
+            if a.get("required") is not None:
+                arg_entry["required"] = a.get("required")
+            if a.get("schema") is not None:
+                arg_entry["schema"] = _canonicalize_schema(a.get("schema"))
+            norm_args.append(arg_entry)
+        norm_args.sort(key=lambda x: x.get("name") or "")
+        norm_prompts.append(
+            {
+                "name": p.get("name"),
+                "description": p.get("description"),
+                "arguments": norm_args,
+            }
+        )
+    norm_prompts.sort(key=lambda x: x.get("name") or "")
+
+    def _canonicalize_manifest_tool_capabilities(tool_caps: Any) -> Any:
+        """
+        Canonicalize the extracted mcp_manifest toolCapabilities list for identity.
+
+        Contract:
+        - toolCapabilities entries are sorted by `tool`
+        - `operations` is treated as an unordered set for identity, represented as a sorted list
+          (duplicates are preserved; duplicate values should be flagged separately as malformed)
+        """
+        if not isinstance(tool_caps, list):
+            return _canonicalize_schema(tool_caps)
+
+        norm: list[dict] = []
+        for e in tool_caps:
+            if not isinstance(e, dict) or not e.get("tool"):
+                # Preserve nonconforming entries deterministically; they still participate in identity.
+                norm.append(_canonicalize_schema(e) if isinstance(e, (dict, list)) else {"value": e})
+                continue
+
+            entry: dict[str, Any] = {"tool": str(e.get("tool"))}
+            if "description" in e:
+                entry["description"] = e.get("description")
+
+            if "operations" in e and isinstance(e.get("operations"), list):
+                ops = e.get("operations") or []
+                # Sort for identity without silently deduping.
+                try:
+                    entry["operations"] = sorted(ops)
+                except TypeError:
+                    entry["operations"] = sorted(ops, key=_normalize_text)
+
+            # Preserve any additional fields deterministically.
+            for k in sorted(set(e.keys()) - {"tool", "description", "operations"}):
+                entry[k] = _canonicalize_schema(e.get(k))
+
+            norm.append(entry)
+
+        norm.sort(key=lambda x: x.get("tool") or "")
+        return norm
+
+    def _canonicalize_decl_source_extracted(extracted: Any) -> Any:
+        if not isinstance(extracted, dict):
+            return _canonicalize_schema(extracted)
+
+        out: dict[str, Any] = {}
+        for k in sorted(extracted.keys()):
+            if k == "toolCapabilities":
+                out[k] = _canonicalize_manifest_tool_capabilities(extracted.get(k))
+            else:
+                out[k] = _canonicalize_schema(extracted.get(k))
+        return out
+
+    norm_decl_sources: list[dict] = []
+    for s in decl_sources:
+        if not isinstance(s, dict):
+            continue
+        # Keep only identity-bearing facts here; errors/notes should live in observation.
+        entry: dict[str, Any] = {}
+        for k in ("sourceType", "name", "uri", "extracted"):
+            if k in s:
+                entry[k] = _canonicalize_decl_source_extracted(s[k]) if k in ("extracted",) else s[k]
+        norm_decl_sources.append(entry)
+    norm_decl_sources.sort(key=lambda x: (x.get("sourceType") or "", x.get("uri") or "", x.get("name") or ""))
+
+    return {
+        "tools": norm_tools,
+        "resources": norm_resources,
+        "resourceTemplates": norm_templates,
+        "prompts": norm_prompts,
+        "declarationSources": norm_decl_sources,
+    }
+
+
+def _compute_surface_digest(surface: dict) -> str:
+    canonical = _canonicalize_surface(surface)
+    return "sha256:" + _sha256_hex(_canonical_json_bytes(canonical))
+
+
+def _surface_entity_digests(surface: dict) -> dict:
+    """Derived per-entity digests (not included in surface hashing)."""
+    canonical = _canonicalize_surface(surface)
+    tool_d: dict[str, str] = {}
+    for t in canonical.get("tools", []):
+        name = t.get("name")
+        if name:
+            tool_d[str(name)] = "sha256:" + _sha256_hex(_canonical_json_bytes(t))
+    prompt_d: dict[str, str] = {}
+    for p in canonical.get("prompts", []):
+        name = p.get("name")
+        if name:
+            prompt_d[str(name)] = "sha256:" + _sha256_hex(_canonical_json_bytes(p))
+    resource_d: dict[str, str] = {}
+    for r in canonical.get("resources", []):
+        uri = r.get("uri")
+        if uri:
+            resource_d[str(uri)] = "sha256:" + _sha256_hex(_canonical_json_bytes(r))
+    template_d: dict[str, str] = {}
+    for t in canonical.get("resourceTemplates", []):
+        uri = t.get("uriTemplate")
+        if uri:
+            template_d[str(uri)] = "sha256:" + _sha256_hex(_canonical_json_bytes(t))
+    return {
+        "tools": tool_d,
+        "prompts": prompt_d,
+        "resources": resource_d,
+        "resourceTemplates": template_d,
+    }
+
+
+def _surface_completeness_from_coverage(coverage: dict) -> str:
+    """Return 'complete' if all identity-bearing sections succeeded or were unsupported."""
+    for key in ("tools", "resources", "resourceTemplates", "prompts", "manifest"):
+        s = coverage.get(key) or {}
+        if not isinstance(s, dict):
+            return "partial"
+        declared = s.get("declaredSupported")
+        attempted = bool(s.get("attempted"))
+        completed = bool(s.get("completed"))
+        # Completed sections are complete regardless of whether they were attempted
+        # (e.g. manifest absent but resources introspection succeeded).
+        if completed:
+            continue
+        # Explicitly unsupported sections count as complete if we did not attempt them.
+        if declared is False and not attempted:
+            continue
+        # For v0.2, 'complete' means we attempted each standard list method (or explicitly
+        # marked the section unsupported) and it completed successfully.
+        if not attempted and declared is not False:
+            return "partial"
+        # Anything else means we don't have a complete declared surface.
+        return "partial"
+    return "complete"
+
+
+def _build_snapshot(
+    *,
+    generated_at: str,
+    scanned_command: list[str],
+    server_name: str,
+    protocol_version: str,
+    capabilities: dict[str, bool],
+    status: str,
+    coverage: dict,
+    surface: dict,
+    tools_for_text: list[dict],
+    risk: dict,
+    signals: list[dict],
+    notes: list[dict],
+    errors: list[dict],
+) -> dict:
+    surface_completeness = _surface_completeness_from_coverage(coverage)
+    snapshot: dict[str, Any] = {
+        "snapshotFormatVersion": "1",
+        "surfaceCompleteness": surface_completeness,
+        "observation": {
+            "generatedAt": generated_at,
+            "protocolVersion": protocol_version,
+            "serverName": server_name,
+            "command": scanned_command,
+            "status": status,
+            "capabilities": capabilities,
+            "coverage": coverage,
+            "notes": notes,
+            "errors": errors,
+            "localAnnotations": {
+                "tools": tools_for_text,
+                "risk": risk,
+                "signals": signals,
+            },
+        },
+        "surface": surface,
+    }
+    if surface_completeness == "complete":
+        try:
+            snapshot["surfaceDigest"] = _compute_surface_digest(surface)
+            snapshot["surfaceEntityDigests"] = _surface_entity_digests(surface)
+        except Exception as e:
+            # Identity must be stable and standards-compliant; fall back to partial if hashing fails.
+            snapshot["surfaceCompleteness"] = "partial"
+            obs = snapshot.get("observation") or {}
+            obs["notes"] = (obs.get("notes") or []) + [
+                {"kind": "snapshot", "name": "surfaceDigest", "rule": "hash_error", "snippet": _normalize_text(str(e))}
+            ]
+            snapshot["observation"] = obs
+    return snapshot
+
+
 async def inspect(
     command: str,
     args: list[str],
@@ -622,13 +1042,41 @@ async def inspect(
             status = "ok"
             errors: list[dict] = []
             notes: list[dict] = []
+            coverage: dict[str, Any] = {
+                "tools": {
+                    "declaredSupported": (True if has_tools else False) if caps is not None else None,
+                    "attempted": True,
+                    "completed": False,
+                },
+                "resources": {
+                    "declaredSupported": (True if has_resources else False) if caps is not None else None,
+                    "attempted": False,
+                    "completed": False,
+                },
+                "resourceTemplates": {
+                    "declaredSupported": (True if has_resources else False) if caps is not None else None,
+                    "attempted": False,
+                    "completed": False,
+                },
+                "prompts": {
+                    "declaredSupported": (True if has_prompts else False) if caps is not None else None,
+                    "attempted": False,
+                    "completed": False,
+                },
+                "manifest": {"declaredSupported": None, "attempted": False, "completed": False},
+            }
 
             # Tools — always attempt even if not declared (many servers omit the capability).
             tools: list[dict] = []
+            tools_surface: list[dict] = []
             try:
                 tools_raw = (await asyncio.wait_for(session.list_tools(), timeout=timeout_s)).tools
                 tools = [_tool_dict(t) for t in tools_raw]
                 tools.sort(key=lambda t: (RISK_PRIORITY.get(t["risk"], 9), t["name"]))
+                tools_surface = [_tool_surface_dict(t) for t in tools_raw]
+                tools_surface.sort(key=lambda t: t.get("name") or "")
+                coverage["tools"]["completed"] = True
+                coverage["tools"]["itemCount"] = len(tools_raw or [])
             except asyncio.TimeoutError:
                 status = _mark_partial(status)
                 errors.append(
@@ -639,6 +1087,7 @@ async def inspect(
                         "snippet": f"Timed out after {timeout_s}s",
                     }
                 )
+                coverage["tools"]["errorRule"] = "timeout"
             except Exception as e:
                 status = _mark_partial(status)
                 errors.append(
@@ -649,54 +1098,116 @@ async def inspect(
                         "snippet": _normalize_text(str(e)),
                     }
                 )
+                coverage["tools"]["errorRule"] = "error"
             risk = count_risks(tools)
 
-            # Resources — skip if server didn't declare the capability.
-            resources = []
-            templates = []
-            if has_resources:
-                try:
-                    resources = (await asyncio.wait_for(session.list_resources(), timeout=timeout_s)).resources
-                except asyncio.TimeoutError:
-                    status = _mark_partial(status)
-                    notes.append(
-                        {"kind": "mcp", "name": "list_resources", "rule": "timeout", "snippet": f"Timed out after {timeout_s}s"}
-                    )
-                except Exception as e:
-                    status = _mark_partial(status)
-                    notes.append(
-                        {"kind": "mcp", "name": "list_resources", "rule": "error", "snippet": _normalize_text(str(e))}
-                    )
-                try:
-                    templates = (
-                        await asyncio.wait_for(session.list_resource_templates(), timeout=timeout_s)
-                    ).resourceTemplates
-                except asyncio.TimeoutError:
+            def _mark_duplicates(items: list[dict], key: str, coverage_key: str) -> None:
+                seen: set[str] = set()
+                dupes: set[str] = set()
+                for it in items:
+                    if not isinstance(it, dict):
+                        continue
+                    v = it.get(key)
+                    if v is None:
+                        continue
+                    s = str(v)
+                    if s in seen:
+                        dupes.add(s)
+                    else:
+                        seen.add(s)
+                if dupes:
+                    nonlocal status
                     status = _mark_partial(status)
                     notes.append(
                         {
-                            "kind": "mcp",
-                            "name": "list_resource_templates",
-                            "rule": "timeout",
-                            "snippet": f"Timed out after {timeout_s}s",
+                            "kind": "snapshot",
+                            "name": coverage_key,
+                            "rule": "duplicate_identity",
+                            "snippet": ", ".join(sorted(dupes))[:500],
                         }
                     )
-                except Exception as e:
+                    coverage[coverage_key]["completed"] = False
+                    coverage[coverage_key]["errorRule"] = "duplicate_identity"
+
+            # Resources — attempt discovery even if not declared (servers may omit capability flags).
+            resources = []
+            templates = []
+            def _looks_unsupported(err: str) -> bool:
+                s = err.lower()
+                return "method not found" in s or "not supported" in s or "unknown method" in s
+
+            coverage["resources"]["attempted"] = True
+            try:
+                resources = (await asyncio.wait_for(session.list_resources(), timeout=timeout_s)).resources
+                coverage["resources"]["completed"] = True
+                coverage["resources"]["declaredSupported"] = True
+                coverage["resources"]["itemCount"] = len(resources or [])
+            except asyncio.TimeoutError:
+                status = _mark_partial(status)
+                notes.append(
+                    {"kind": "mcp", "name": "list_resources", "rule": "timeout", "snippet": f"Timed out after {timeout_s}s"}
+                )
+                coverage["resources"]["errorRule"] = "timeout"
+            except Exception as e:
+                msg = _normalize_text(str(e))
+                if _looks_unsupported(msg):
+                    coverage["resources"]["completed"] = True
+                    coverage["resources"]["declaredSupported"] = False
+                else:
                     status = _mark_partial(status)
-                    notes.append(
-                        {"kind": "mcp", "name": "list_resource_templates", "rule": "error", "snippet": _normalize_text(str(e))}
-                    )
+                    notes.append({"kind": "mcp", "name": "list_resources", "rule": "error", "snippet": msg})
+                    coverage["resources"]["errorRule"] = "error"
+
+            coverage["resourceTemplates"]["attempted"] = True
+            try:
+                templates = (await asyncio.wait_for(session.list_resource_templates(), timeout=timeout_s)).resourceTemplates
+                coverage["resourceTemplates"]["completed"] = True
+                coverage["resourceTemplates"]["declaredSupported"] = True
+                coverage["resourceTemplates"]["itemCount"] = len(templates or [])
+            except asyncio.TimeoutError:
+                status = _mark_partial(status)
+                notes.append(
+                    {
+                        "kind": "mcp",
+                        "name": "list_resource_templates",
+                        "rule": "timeout",
+                        "snippet": f"Timed out after {timeout_s}s",
+                    }
+                )
+                coverage["resourceTemplates"]["errorRule"] = "timeout"
+            except Exception as e:
+                msg = _normalize_text(str(e))
+                if _looks_unsupported(msg):
+                    coverage["resourceTemplates"]["completed"] = True
+                    coverage["resourceTemplates"]["declaredSupported"] = False
+                else:
+                    status = _mark_partial(status)
+                    notes.append({"kind": "mcp", "name": "list_resource_templates", "rule": "error", "snippet": msg})
+                    coverage["resourceTemplates"]["errorRule"] = "error"
             resource_uris = sorted([str(r.uri) for r in resources])
             template_uris = sorted([str(t.uriTemplate) for t in templates])
+            resources_surface: list[dict] = []
+            templates_surface: list[dict] = []
+            try:
+                resources_surface = [_resource_surface_dict(r) for r in resources]
+                templates_surface = [_resource_template_surface_dict(t) for t in templates]
+            except TypeError as e:
+                status = _mark_partial(status)
+                notes.append({"kind": "snapshot", "name": "surface", "rule": "non_json_identity", "snippet": _normalize_text(str(e))})
+                coverage["resources"]["completed"] = False
+                coverage["resources"]["errorRule"] = "non_json_identity"
+                coverage["resourceTemplates"]["completed"] = False
+                coverage["resourceTemplates"]["errorRule"] = "non_json_identity"
 
-            # Manifest resource — read-only, no call_tool, no state mutation.
-            tool_capabilities: list[dict] | None = None
+            # Manifest resource — Preflight does not call tools, but any MCP request may execute arbitrary server code.
+            declaration_sources: list[dict] = []
             if resources:
                 caps_resource = next(
                     (r for r in resources if str(r.uri).endswith("://mcp/manifest")),
                     None,
                 )
                 if caps_resource:
+                    coverage["manifest"]["attempted"] = True
                     try:
                         read_result = await asyncio.wait_for(
                             session.read_resource(caps_resource.uri), timeout=timeout_s
@@ -704,29 +1215,110 @@ async def inspect(
                         if read_result.contents:
                             raw_text = getattr(read_result.contents[0], "text", None)
                             if raw_text:
+                                raw_hash = "sha256:" + _sha256_hex(raw_text.encode("utf-8"))
                                 caps_data = _parse_capabilities_resource(raw_text)
                                 if caps_data is not None:
                                     tool_capabilities = _expand_tool_capabilities(caps_data)
-                    except Exception:
-                        pass  # Skip silently on any error.
+                                    # Duplicate operation values are malformed; do not silently repair.
+                                    dupes: list[str] = []
+                                    for e in tool_capabilities:
+                                        ops = e.get("operations")
+                                        if isinstance(ops, list) and ops:
+                                            d = _find_list_duplicates(ops)
+                                            if d:
+                                                tool = str(e.get("tool") or "unknown")
+                                                try:
+                                                    dupes.append(f"{tool}: {', '.join(str(x) for x in d)}")
+                                                except Exception:
+                                                    dupes.append(tool)
+                                    if dupes:
+                                        status = _mark_partial(status)
+                                        notes.append(
+                                            {
+                                                "kind": "declaration_source",
+                                                "name": "mcp_manifest",
+                                                "rule": "duplicate_operations",
+                                                "snippet": "; ".join(dupes)[:700],
+                                            }
+                                        )
+                                        coverage["manifest"]["completed"] = False
+                                        coverage["manifest"]["errorRule"] = "duplicate_operations"
 
-            # Prompts — skip if server didn't declare the capability.
+                                    declaration_sources.append(
+                                        {
+                                            "sourceType": "resource",
+                                            "name": "mcp_manifest",
+                                            "uri": str(caps_resource.uri),
+                                            "extracted": {"toolCapabilities": tool_capabilities},
+                                        }
+                                    )
+                                    # Provenance (non-identity) belongs in observation notes.
+                                    notes.append(
+                                        {
+                                            "kind": "declaration_source",
+                                            "name": "mcp_manifest",
+                                            "rule": "parsed",
+                                            "snippet": raw_hash,
+                                        }
+                                    )
+                                    coverage["manifest"]["completed"] = True
+                                else:
+                                    status = _mark_partial(status)
+                                    notes.append(
+                                        {
+                                            "kind": "declaration_source",
+                                            "name": "mcp_manifest",
+                                            "rule": "invalid",
+                                            "snippet": raw_hash,
+                                        }
+                                    )
+                                    coverage["manifest"]["errorRule"] = "invalid"
+                    except Exception:
+                        status = _mark_partial(status)
+                        notes.append(
+                            {"kind": "declaration_source", "name": "mcp_manifest", "rule": "error", "snippet": "read_resource failed"}
+                        )
+                        coverage["manifest"]["errorRule"] = "error"
+                else:
+                    # Not present; counts as complete (no attempt).
+                    coverage["manifest"]["attempted"] = False
+                    coverage["manifest"]["completed"] = True
+            else:
+                # If resources were supported but list_resources failed, manifest completeness is unknown → partial.
+                if has_resources and coverage["resources"].get("completed") is not True:
+                    coverage["manifest"]["attempted"] = False
+                    coverage["manifest"]["completed"] = False
+                else:
+                    coverage["manifest"]["attempted"] = False
+                    coverage["manifest"]["completed"] = True
+
+            # Prompts — attempt discovery even if not declared (servers may omit capability flags).
             prompts = []
-            if has_prompts:
-                try:
-                    prompts = (await asyncio.wait_for(session.list_prompts(), timeout=timeout_s)).prompts
-                except asyncio.TimeoutError:
+            coverage["prompts"]["attempted"] = True
+            try:
+                prompts = (await asyncio.wait_for(session.list_prompts(), timeout=timeout_s)).prompts
+                coverage["prompts"]["completed"] = True
+                coverage["prompts"]["declaredSupported"] = True
+                coverage["prompts"]["itemCount"] = len(prompts or [])
+            except asyncio.TimeoutError:
+                status = _mark_partial(status)
+                notes.append(
+                    {"kind": "mcp", "name": "list_prompts", "rule": "timeout", "snippet": f"Timed out after {timeout_s}s"}
+                )
+                coverage["prompts"]["errorRule"] = "timeout"
+            except Exception as e:
+                msg = _normalize_text(str(e))
+                if _looks_unsupported(msg):
+                    coverage["prompts"]["completed"] = True
+                    coverage["prompts"]["declaredSupported"] = False
+                else:
                     status = _mark_partial(status)
-                    notes.append(
-                        {"kind": "mcp", "name": "list_prompts", "rule": "timeout", "snippet": f"Timed out after {timeout_s}s"}
-                    )
-                except Exception as e:
-                    status = _mark_partial(status)
-                    notes.append(
-                        {"kind": "mcp", "name": "list_prompts", "rule": "error", "snippet": _normalize_text(str(e))}
-                    )
+                    notes.append({"kind": "mcp", "name": "list_prompts", "rule": "error", "snippet": msg})
+                    coverage["prompts"]["errorRule"] = "error"
             prompts_info = [_prompt_dict(p) for p in prompts]
             prompts_info.sort(key=lambda p: p.get("name", ""))
+            prompts_surface = [_prompt_surface_dict(p) for p in prompts]
+            prompts_surface.sort(key=lambda p: p.get("name") or "")
 
             signals: list[dict] = []
             if include_signals:
@@ -734,126 +1326,647 @@ async def inspect(
 
             notes.sort(key=lambda n: (n.get("kind", ""), n.get("name", ""), n.get("rule", "")))
 
-            return _build_report(
+            # Duplicate detection (identity must be unambiguous).
+            _mark_duplicates(tools_surface, "name", "tools")
+            _mark_duplicates(resources_surface, "uri", "resources")
+            _mark_duplicates(templates_surface, "uriTemplate", "resourceTemplates")
+            _mark_duplicates(prompts_surface, "name", "prompts")
+
+            generated_at = datetime.now(timezone.utc).isoformat()
+            surface = {
+                "tools": tools_surface,
+                "resources": resources_surface,
+                "resourceTemplates": templates_surface,
+                "prompts": prompts_surface,
+                "declarationSources": declaration_sources,
+            }
+            return _build_snapshot(
+                generated_at=generated_at,
                 scanned_command=[command, *args],
                 server_name=server_name,
                 protocol_version=protocol_version,
-                capabilities={"tools": has_tools, "resources": has_resources, "prompts": has_prompts},
+                capabilities={"tools": bool(has_tools), "resources": bool(has_resources), "prompts": bool(has_prompts)},
                 status=status,
-                tools=tools,
-                resource_uris=resource_uris,
-                template_uris=template_uris,
-                prompts=prompts_info,
+                coverage=coverage,
+                surface=surface,
+                tools_for_text=tools,
+                risk=risk,
                 signals=signals,
                 notes=notes,
-                risk=risk,
                 errors=errors,
-                tool_capabilities=tool_capabilities,
             )
 
 
+def _json_pointer_escape_token(token: str) -> str:
+    return token.replace("~", "~0").replace("/", "~1")
+
+
+def _manifest_tool_caps_entry_map_from_surface(surface: dict) -> dict[str, dict]:
+    """
+    Return manifest tool -> capability entry mapping from a (canonical) surface dict.
+
+    Note: this uses canonicalized declarationSources, so toolCapabilities ordering and operations
+    ordering should already be normalized by `_canonicalize_surface`.
+    """
+    caps: dict[str, dict] = {}
+    for src in surface.get("declarationSources") or []:
+        if not isinstance(src, dict) or src.get("name") != "mcp_manifest":
+            continue
+        extracted = src.get("extracted") or {}
+        if not isinstance(extracted, dict):
+            continue
+        for e in (extracted.get("toolCapabilities") or []):
+            if isinstance(e, dict) and e.get("tool"):
+                caps[str(e["tool"])] = e
+    return caps
+
+
+def _compute_surface_changes(before_surface: dict, after_surface: dict) -> list[dict]:
+    """
+    Compute stable factual change records between two surfaces.
+
+    Important: paths emitted here are stable semantic paths (JSON-Pointer-escaped) and are not
+    guaranteed to be literal pointers into the array-based serialized snapshot.
+    """
+    b = _canonicalize_surface(before_surface or {})
+    a = _canonicalize_surface(after_surface or {})
+
+    changes: list[dict] = []
+
+    def add(rec: dict) -> None:
+        changes.append(rec)
+
+    def map_by(items: list[dict], key: str) -> dict[str, dict]:
+        out: dict[str, dict] = {}
+        for it in items or []:
+            if isinstance(it, dict) and it.get(key):
+                out[str(it[key])] = it
+        return out
+
+    # Tools
+    bt = map_by(b.get("tools") or [], "name")
+    at = map_by(a.get("tools") or [], "name")
+    for name in sorted(set(at) - set(bt)):
+        add({"type": "tool_added", "entityType": "tool", "entityId": name, "path": ""})
+    for name in sorted(set(bt) - set(at)):
+        add({"type": "tool_removed", "entityType": "tool", "entityId": name, "path": ""})
+    for name in sorted(set(bt) & set(at)):
+        btool = bt[name]
+        atool = at[name]
+        if (btool.get("description") or "") != (atool.get("description") or ""):
+            add(
+                {
+                    "type": "value_changed",
+                    "entityType": "tool",
+                    "entityId": name,
+                    "path": "/description",
+                    "before": btool.get("description"),
+                    "after": atool.get("description"),
+                }
+            )
+        if btool.get("inputSchema") != atool.get("inputSchema"):
+            add(
+                {
+                    "type": "value_changed",
+                    "entityType": "tool",
+                    "entityId": name,
+                    "path": "/inputSchema",
+                    "before": btool.get("inputSchema"),
+                    "after": atool.get("inputSchema"),
+                }
+            )
+
+    # Resources
+    br = map_by(b.get("resources") or [], "uri")
+    ar = map_by(a.get("resources") or [], "uri")
+    for uri in sorted(set(ar) - set(br)):
+        add({"type": "resource_added", "entityType": "resource", "entityId": uri, "path": ""})
+    for uri in sorted(set(br) - set(ar)):
+        add({"type": "resource_removed", "entityType": "resource", "entityId": uri, "path": ""})
+    for uri in sorted(set(br) & set(ar)):
+        bres = br[uri]
+        ares = ar[uri]
+        for field in ("name", "title", "description", "mimeType", "annotations"):
+            if bres.get(field) != ares.get(field):
+                add(
+                    {
+                        "type": "value_changed",
+                        "entityType": "resource",
+                        "entityId": uri,
+                        "path": f"/{field}",
+                        "before": bres.get(field),
+                        "after": ares.get(field),
+                    }
+                )
+
+    # Resource templates
+    btpl = map_by(b.get("resourceTemplates") or [], "uriTemplate")
+    atpl = map_by(a.get("resourceTemplates") or [], "uriTemplate")
+    for uri in sorted(set(atpl) - set(btpl)):
+        add({"type": "resource_template_added", "entityType": "resource_template", "entityId": uri, "path": ""})
+    for uri in sorted(set(btpl) - set(atpl)):
+        add({"type": "resource_template_removed", "entityType": "resource_template", "entityId": uri, "path": ""})
+    for uri in sorted(set(btpl) & set(atpl)):
+        btmp = btpl[uri]
+        atmp = atpl[uri]
+        for field in ("name", "title", "description", "mimeType", "annotations"):
+            if btmp.get(field) != atmp.get(field):
+                add(
+                    {
+                        "type": "value_changed",
+                        "entityType": "resource_template",
+                        "entityId": uri,
+                        "path": f"/{field}",
+                        "before": btmp.get(field),
+                        "after": atmp.get(field),
+                    }
+                )
+
+    # Prompts
+    bp = map_by(b.get("prompts") or [], "name")
+    ap = map_by(a.get("prompts") or [], "name")
+    for name in sorted(set(ap) - set(bp)):
+        add({"type": "prompt_added", "entityType": "prompt", "entityId": name, "path": ""})
+    for name in sorted(set(bp) - set(ap)):
+        add({"type": "prompt_removed", "entityType": "prompt", "entityId": name, "path": ""})
+    for name in sorted(set(bp) & set(ap)):
+        bpr = bp[name]
+        apr = ap[name]
+        if bpr.get("description") != apr.get("description"):
+            add(
+                {
+                    "type": "value_changed",
+                    "entityType": "prompt",
+                    "entityId": name,
+                    "path": "/description",
+                    "before": bpr.get("description"),
+                    "after": apr.get("description"),
+                }
+            )
+
+        b_args = map_by(bpr.get("arguments") or [], "name")
+        a_args = map_by(apr.get("arguments") or [], "name")
+        for arg in sorted(set(a_args) - set(b_args)):
+            add(
+                {
+                    "type": "value_added",
+                    "entityType": "prompt",
+                    "entityId": name,
+                    "path": f"/arguments/{_json_pointer_escape_token(arg)}",
+                    "value": a_args[arg],
+                }
+            )
+        for arg in sorted(set(b_args) - set(a_args)):
+            add(
+                {
+                    "type": "value_removed",
+                    "entityType": "prompt",
+                    "entityId": name,
+                    "path": f"/arguments/{_json_pointer_escape_token(arg)}",
+                    "value": b_args[arg],
+                }
+            )
+        for arg in sorted(set(b_args) & set(a_args)):
+            ba = b_args[arg]
+            aa = a_args[arg]
+            for field in ("description", "required", "schema"):
+                if ba.get(field) != aa.get(field):
+                    add(
+                        {
+                            "type": "value_changed",
+                            "entityType": "prompt",
+                            "entityId": name,
+                            "path": f"/arguments/{_json_pointer_escape_token(arg)}/{field}",
+                            "before": ba.get(field),
+                            "after": aa.get(field),
+                        }
+                    )
+
+    # Declaration sources (identity: (sourceType, name, uri))
+    def src_key(s: dict) -> tuple[str, str, str]:
+        return (str(s.get("sourceType") or ""), str(s.get("name") or ""), str(s.get("uri") or ""))
+
+    b_src_map: dict[tuple[str, str, str], dict] = {}
+    for s in (b.get("declarationSources") or []):
+        if isinstance(s, dict):
+            b_src_map[src_key(s)] = s
+
+    a_src_map: dict[tuple[str, str, str], dict] = {}
+    for s in (a.get("declarationSources") or []):
+        if isinstance(s, dict):
+            a_src_map[src_key(s)] = s
+
+    for k in sorted(set(a_src_map) - set(b_src_map)):
+        add(
+            {
+                "type": "declaration_source_added",
+                "entityType": "declaration_source",
+                "entityId": "|".join(k),
+                "path": "",
+            }
+        )
+    for k in sorted(set(b_src_map) - set(a_src_map)):
+        add(
+            {
+                "type": "declaration_source_removed",
+                "entityType": "declaration_source",
+                "entityId": "|".join(k),
+                "path": "",
+            }
+        )
+    for k in sorted(set(b_src_map) & set(a_src_map)):
+        bs = b_src_map[k]
+        a_s = a_src_map[k]
+        if bs.get("extracted") != a_s.get("extracted"):
+            add(
+                {
+                    "type": "value_changed",
+                    "entityType": "declaration_source",
+                    "entityId": "|".join(k),
+                    "path": "/extracted",
+                    "before": bs.get("extracted"),
+                    "after": a_s.get("extracted"),
+                }
+            )
+
+    # Manifest / capabilities (declarationSources)
+    b_caps = _manifest_tool_caps_entry_map_from_surface(b)
+    a_caps = _manifest_tool_caps_entry_map_from_surface(a)
+    for tool in sorted(set(a_caps) - set(b_caps)):
+        add({"type": "manifest_tool_added", "entityType": "manifest_tool", "entityId": tool, "path": ""})
+    for tool in sorted(set(b_caps) - set(a_caps)):
+        add({"type": "manifest_tool_removed", "entityType": "manifest_tool", "entityId": tool, "path": ""})
+    for tool in sorted(set(b_caps) & set(a_caps)):
+        be = b_caps.get(tool) or {}
+        ae = a_caps.get(tool) or {}
+        if be.get("description") != ae.get("description"):
+            add(
+                {
+                    "type": "value_changed",
+                    "entityType": "manifest_tool",
+                    "entityId": tool,
+                    "path": "/description",
+                    "before": be.get("description"),
+                    "after": ae.get("description"),
+                }
+            )
+
+        b_ops = be.get("operations") or []
+        a_ops = ae.get("operations") or []
+        # Canonical form is sorted list; order changes should not appear here.
+        if b_ops != a_ops:
+            add(
+                {
+                    "type": "manifest_tool_changed",
+                    "entityType": "manifest_tool",
+                    "entityId": tool,
+                    "path": "/operations",
+                    "beforeCount": len(b_ops),
+                    "afterCount": len(a_ops),
+                }
+            )
+            try:
+                bset = set(b_ops)
+                aset = set(a_ops)
+                for op in sorted(aset - bset):
+                    add(
+                        {
+                            "type": "value_added",
+                            "entityType": "manifest_tool",
+                            "entityId": tool,
+                            "path": "/operations",
+                            "value": op,
+                        }
+                    )
+                for op in sorted(bset - aset):
+                    add(
+                        {
+                            "type": "value_removed",
+                            "entityType": "manifest_tool",
+                            "entityId": tool,
+                            "path": "/operations",
+                            "value": op,
+                        }
+                    )
+            except TypeError:
+                # Fall back to whole-list change only (still satisfies parity invariants).
+                pass
+
+    changes.sort(key=lambda r: (r.get("entityType", ""), r.get("entityId", ""), r.get("type", ""), r.get("path", "")))
+    return changes
+
+
 def diff_reports(before: dict, after: dict) -> str:
-    def tool_map(r: dict) -> dict[str, dict]:
-        return {t["name"]: t for t in r.get("tools", [])}
+    SUPPORTED_SNAPSHOT_FORMATS = {"1"}
 
-    before_tools = tool_map(before)
-    after_tools = tool_map(after)
-    added = sorted(set(after_tools) - set(before_tools))
-    removed = sorted(set(before_tools) - set(after_tools))
-    changed_risk = sorted(
-        name
-        for name in (set(before_tools) & set(after_tools))
-        if before_tools[name].get("risk") != after_tools[name].get("risk")
-    )
+    def is_snapshot(d: dict) -> bool:
+        return isinstance(d, dict) and "snapshotFormatVersion" in d and "surface" in d and "observation" in d
 
-    def list_diff(before_list: list[str], after_list: list[str]) -> tuple[list[str], list[str]]:
-        return sorted(set(after_list) - set(before_list)), sorted(set(before_list) - set(after_list))
+    def legacy_to_snapshot(r: dict) -> tuple[dict, str]:
+        server = r.get("server") or {}
+        generated_at = r.get("generatedAt") or datetime.now(timezone.utc).isoformat()
+        protocol_version = server.get("protocolVersion") or "unknown"
+        server_name = server.get("name") or "unknown"
+        scanned = r.get("scannedCommand") or []
+        status = r.get("status") or "ok"
+        capabilities = r.get("capabilities") or {"tools": False, "resources": False, "prompts": False}
+        notes = r.get("notes") or []
+        errors = r.get("errors") or []
+        local_tools = r.get("tools") or []
+        risk = r.get("risk") or {}
+        signals = r.get("signals") or []
 
-    res_added, res_removed = list_diff(before.get("resources", []), after.get("resources", []))
-    tmpl_added, tmpl_removed = list_diff(before.get("resourceTemplates", []), after.get("resourceTemplates", []))
+        # Legacy lacks tool schemas; treat as partial.
+        surface_tools = [{"name": t.get("name"), "description": t.get("description"), "inputSchema": None} for t in (local_tools or []) if isinstance(t, dict)]
+        surface_resources = [{"uri": u} for u in (r.get("resources") or [])]
+        surface_templates = [{"uriTemplate": u} for u in (r.get("resourceTemplates") or [])]
+        legacy_prompts = []
+        for p in (r.get("prompts") or []):
+            if not isinstance(p, dict):
+                continue
+            arg_objs = []
+            for a in (p.get("arguments") or []):
+                arg_objs.append({"name": a})
+            legacy_prompts.append({"name": p.get("name"), "description": p.get("description"), "arguments": arg_objs})
+        decl_sources: list[dict] = []
+        if isinstance(r.get("manifest"), list):
+            decl_sources.append(
+                {
+                    "sourceType": "legacy",
+                    "name": "mcp_manifest",
+                    "uri": None,
+                    "status": "parsed",
+                    "extracted": {"toolCapabilities": r.get("manifest")},
+                }
+            )
 
-    before_prompts = sorted(p.get("name") for p in before.get("prompts", []) if p.get("name"))
-    after_prompts = sorted(p.get("name") for p in after.get("prompts", []) if p.get("name"))
-    pr_added, pr_removed = list_diff(before_prompts, after_prompts)
+        coverage = {
+            "tools": {"declaredSupported": None, "attempted": False, "completed": False, "errorRule": "legacy"},
+            "resources": {"declaredSupported": None, "attempted": False, "completed": False, "errorRule": "legacy"},
+            "resourceTemplates": {"declaredSupported": None, "attempted": False, "completed": False, "errorRule": "legacy"},
+            "prompts": {"declaredSupported": None, "attempted": False, "completed": False, "errorRule": "legacy"},
+            "manifest": {"declaredSupported": None, "attempted": False, "completed": False, "errorRule": "legacy"},
+        }
+        snap = _build_snapshot(
+            generated_at=str(generated_at),
+            scanned_command=list(scanned) if isinstance(scanned, list) else [],
+            server_name=str(server_name),
+            protocol_version=str(protocol_version),
+            capabilities=capabilities,
+            status=str(status),
+            coverage=coverage,
+            surface={
+                "tools": surface_tools,
+                "resources": surface_resources,
+                "resourceTemplates": surface_templates,
+                "prompts": legacy_prompts,
+                "declarationSources": decl_sources,
+            },
+            tools_for_text=list(local_tools) if isinstance(local_tools, list) else [],
+            risk=risk,
+            signals=signals,
+            notes=notes,
+            errors=errors,
+        )
+        # Force legacy conversion to partial regardless of coverage heuristics.
+        snap["surfaceCompleteness"] = "partial"
+        snap.pop("surfaceDigest", None)
+        snap.pop("surfaceEntityDigests", None)
+        return snap, "Legacy report: tool schemas were not captured; structural comparison is limited."
 
-    def fmt_risk(r: dict) -> str:
-        rr = r.get("risk", {}) if isinstance(r, dict) else {}
-        return f'{rr.get("write", 0)} write, {rr.get("destructive", 0)} destructive, {rr.get("read", 0)} read-only'
+    def coerce_snapshot(d: dict) -> tuple[dict, list[str]]:
+        if is_snapshot(d):
+            ver = str(d.get("snapshotFormatVersion"))
+            if ver not in SUPPORTED_SNAPSHOT_FORMATS:
+                raise ValueError(f"Unsupported snapshotFormatVersion: {ver}")
+            return d, []
+        snap, w = legacy_to_snapshot(d)
+        return snap, [w]
+
+    b, bw = coerce_snapshot(before)
+    a, aw = coerce_snapshot(after)
+    warnings = bw + aw
+
+    b_obs = b.get("observation") or {}
+    a_obs = a.get("observation") or {}
+    b_surface = b.get("surface") or {}
+    a_surface = a.get("surface") or {}
+    b_can = _canonicalize_surface(b_surface)
+    a_can = _canonicalize_surface(a_surface)
 
     lines: list[str] = []
     lines.append("Diff\n")
-    lines.append(f'  Before: {before.get("server", {}).get("name", "unknown")} ({fmt_risk(before)})')
-    lines.append(f'  After:  {after.get("server", {}).get("name", "unknown")} ({fmt_risk(after)})\n')
+    for w in warnings:
+        lines.append(f"  WARNING: {w}")
+    if warnings:
+        lines.append("")
 
-    if added or removed or changed_risk:
+    b_name = b_obs.get("serverName", "unknown")
+    a_name = a_obs.get("serverName", "unknown")
+    b_comp = b.get("surfaceCompleteness", "partial")
+    a_comp = a.get("surfaceCompleteness", "partial")
+    lines.append(f"  Before: {b_name} (surface: {b_comp})")
+    lines.append(f"  After:  {a_name} (surface: {a_comp})")
+
+    b_digest = b.get("surfaceDigest")
+    a_digest = a.get("surfaceDigest")
+    if b_digest and a_digest:
+        lines.append(f"\n  surfaceDigest:\n    before: {b_digest}\n    after:  {a_digest}\n")
+    else:
+        lines.append("")
+        if b_comp != "complete" or a_comp != "complete":
+            lines.append("  Note: surfaceDigest is omitted unless both surfaces are complete.\n")
+
+    def tool_map(surface: dict) -> dict[str, dict]:
+        out: dict[str, dict] = {}
+        for t in surface.get("tools") or []:
+            if isinstance(t, dict) and t.get("name"):
+                out[str(t["name"])] = t
+        return out
+
+    def prompt_map(surface: dict) -> dict[str, dict]:
+        out: dict[str, dict] = {}
+        for p in surface.get("prompts") or []:
+            if isinstance(p, dict) and p.get("name"):
+                out[str(p["name"])] = p
+        return out
+
+    def map_by(items: list[dict], key: str) -> dict[str, dict]:
+        out: dict[str, dict] = {}
+        for it in items or []:
+            if isinstance(it, dict) and it.get(key):
+                out[str(it[key])] = it
+        return out
+
+    def diff_values(path: str, bv: Any, av: Any, out_lines: list[str], *, limit: int = 60) -> None:
+        diffs: list[tuple[str, Any, Any]] = []
+
+        def rec(p: str, x: Any, y: Any) -> None:
+            if x == y:
+                return
+            if type(x) != type(y):
+                diffs.append((p, x, y))
+                return
+            if isinstance(x, dict):
+                keys = sorted(set(x.keys()) | set(y.keys()))
+                for k in keys:
+                    if k not in x:
+                        diffs.append((f"{p}.{k}" if p else k, None, y.get(k)))
+                    elif k not in y:
+                        diffs.append((f"{p}.{k}" if p else k, x.get(k), None))
+                    else:
+                        rec(f"{p}.{k}" if p else k, x.get(k), y.get(k))
+                return
+            if isinstance(x, list):
+                # Improve readability for common schema list expansions.
+                if p.endswith(".enum") or p.endswith(".required"):
+                    try:
+                        xb = set(x)
+                        yb = set(y)
+                        added = sorted(yb - xb)
+                        removed = sorted(xb - yb)
+                        if added:
+                            diffs.append((p + " (+)", added, None))
+                        if removed:
+                            diffs.append((p + " (-)", removed, None))
+                        return
+                    except TypeError:
+                        pass
+                diffs.append((p, x, y))
+                return
+            diffs.append((p, x, y))
+
+        rec(path, bv, av)
+        for i, (p, x, y) in enumerate(diffs):
+            if i >= limit:
+                out_lines.append(f"    … ({len(diffs) - limit} more changes)")
+                break
+            out_lines.append(f"    ~ {p}: {json.dumps(x, ensure_ascii=False)[:160]} -> {json.dumps(y, ensure_ascii=False)[:160]}")
+
+    # Tools
+    b_tools = tool_map(b_can)
+    a_tools = tool_map(a_can)
+    t_added = sorted(set(a_tools) - set(b_tools))
+    t_removed = sorted(set(b_tools) - set(a_tools))
+    t_common = sorted(set(b_tools) & set(a_tools))
+    tool_changes: list[str] = []
+    for name in t_common:
+        bt = b_tools[name]
+        at = a_tools[name]
+        if (bt.get("description") or "") != (at.get("description") or ""):
+            tool_changes.append(f"    ~ {name}.description")
+        if _canonical_json_bytes(bt.get("inputSchema")) != _canonical_json_bytes(at.get("inputSchema")):
+            tool_changes.append(f"    ~ {name}.inputSchema")
+
+    if t_added or t_removed or tool_changes:
         lines.append("  Tools:")
-        for name in added:
-            lines.append(f'    + {name} ({after_tools[name].get("risk")})')
-        for name in removed:
-            lines.append(f'    - {name} ({before_tools[name].get("risk")})')
-        for name in changed_risk:
-            lines.append(f'    ~ {name}: {before_tools[name].get("risk")} -> {after_tools[name].get("risk")}')
+        for n in t_added:
+            lines.append(f"    + {n}")
+        for n in t_removed:
+            lines.append(f"    - {n}")
+        # Expand per-tool structural diffs for changed tools (bounded).
+        for name in t_common:
+            bt = b_tools[name]
+            at = a_tools[name]
+            if (bt.get("description") or "") != (at.get("description") or ""):
+                lines.append(f"    ~ {name}.description: {json.dumps(bt.get('description'), ensure_ascii=False)} -> {json.dumps(at.get('description'), ensure_ascii=False)}")
+            b_schema = bt.get("inputSchema")
+            a_schema = at.get("inputSchema")
+            if _canonical_json_bytes(b_schema) != _canonical_json_bytes(a_schema):
+                lines.append(f"    ~ {name}.inputSchema:")
+                diff_values(f"{name}.inputSchema", b_schema, a_schema, lines, limit=25)
         lines.append("")
 
-    if res_added or res_removed or tmpl_added or tmpl_removed:
+    # Resources / templates
+    b_res = map_by(b_can.get("resources") or [], "uri")
+    a_res = map_by(a_can.get("resources") or [], "uri")
+    b_tmpl = map_by(b_can.get("resourceTemplates") or [], "uriTemplate")
+    a_tmpl = map_by(a_can.get("resourceTemplates") or [], "uriTemplate")
+    res_added = sorted(set(a_res) - set(b_res))
+    res_removed = sorted(set(b_res) - set(a_res))
+    res_common = sorted(set(b_res) & set(a_res))
+    res_changed = [u for u in res_common if b_res[u] != a_res[u]]
+    tmpl_added = sorted(set(a_tmpl) - set(b_tmpl))
+    tmpl_removed = sorted(set(b_tmpl) - set(a_tmpl))
+    tmpl_common = sorted(set(b_tmpl) & set(a_tmpl))
+    tmpl_changed = [u for u in tmpl_common if b_tmpl[u] != a_tmpl[u]]
+    if res_added or res_removed or res_changed or tmpl_added or tmpl_removed or tmpl_changed:
         lines.append("  Resources:")
-        for uri in res_added:
-            lines.append(f"    + {uri}")
-        for uri in res_removed:
-            lines.append(f"    - {uri}")
-        for uri in tmpl_added:
-            lines.append(f"    + {uri}")
-        for uri in tmpl_removed:
-            lines.append(f"    - {uri}")
+        for u in res_added:
+            lines.append(f"    + {u}")
+        for u in res_removed:
+            lines.append(f"    - {u}")
+        for u in res_changed:
+            lines.append(f"    ~ {u}")
+        for u in tmpl_added:
+            lines.append(f"    + {u}")
+        for u in tmpl_removed:
+            lines.append(f"    - {u}")
+        for u in tmpl_changed:
+            lines.append(f"    ~ {u}")
         lines.append("")
 
-    if pr_added or pr_removed:
+    # Prompts
+    b_prompts = prompt_map(b_can)
+    a_prompts = prompt_map(a_can)
+    p_added = sorted(set(a_prompts) - set(b_prompts))
+    p_removed = sorted(set(b_prompts) - set(a_prompts))
+    p_common = sorted(set(b_prompts) & set(a_prompts))
+    p_changed: list[str] = []
+    for name in p_common:
+        bp = b_prompts[name]
+        ap = a_prompts[name]
+        if bp != ap:
+            p_changed.append(name)
+    if p_added or p_removed or p_changed:
         lines.append("  Prompts:")
-        for name in pr_added:
-            lines.append(f"    + {name}")
-        for name in pr_removed:
-            lines.append(f"    - {name}")
+        for n in p_added:
+            lines.append(f"    + {n}")
+        for n in p_removed:
+            lines.append(f"    - {n}")
+        for n in p_changed:
+            lines.append(f"    ~ {n}")
         lines.append("")
 
-    # Manifest / action-level capability diff.
-    def caps_map(r: dict) -> dict[str, list[str] | None]:
-        return {
-            e["tool"]: e.get("operations")
-            for e in r.get("manifest", [])
-            if isinstance(e, dict) and "tool" in e
-        }
-
-    before_caps = caps_map(before)
-    after_caps = caps_map(after)
+    # Manifest / action-level capability diff (from declarationSources).
+    before_caps = _manifest_tool_caps_entry_map_from_surface(b_can)
+    after_caps = _manifest_tool_caps_entry_map_from_surface(a_can)
     caps_added = sorted(set(after_caps) - set(before_caps))
     caps_removed = sorted(set(before_caps) - set(after_caps))
     caps_changed: list[tuple[str, list[str], list[str]]] = []
     for name in sorted(set(before_caps) & set(after_caps)):
-        b_ops = set(before_caps[name] or [])
-        a_ops = set(after_caps[name] or [])
-        if b_ops != a_ops:
+        be = before_caps.get(name) or {}
+        ae = after_caps.get(name) or {}
+        b_ops_raw = be.get("operations") or []
+        a_ops_raw = ae.get("operations") or []
+        try:
+            b_ops = set(b_ops_raw)
+            a_ops = set(a_ops_raw)
+        except TypeError:
+            # If operations aren't hashable, fall back to whole-list comparison.
+            if b_ops_raw != a_ops_raw:
+                caps_changed.append((name, [], []))
+            continue
+        # If any identity-bearing manifest metadata changed, treat as a manifest change.
+        if be != ae:
             ops_added = sorted(a_ops - b_ops)
             ops_removed = sorted(b_ops - a_ops)
             caps_changed.append((name, ops_added, ops_removed))
 
     has_caps_diff = caps_added or caps_removed or caps_changed
     if has_caps_diff:
-        # "now visible" when the before report had no manifest at all.
-        if not before_caps and after_caps:
-            lines.append("  Capabilities (now visible):")
-        else:
-            lines.append("  Capabilities:")
+        lines.append("  Capabilities (manifest-declared):")
         for name in caps_added:
-            ops = after_caps[name]
+            ops = (after_caps.get(name) or {}).get("operations")
             count = f" ({len(ops)} operations)" if ops else ""
             lines.append(f"    + {name}{count}")
         for name in caps_removed:
-            ops = before_caps[name]
+            ops = (before_caps.get(name) or {}).get("operations")
             count = f" ({len(ops)} operations)" if ops else ""
             lines.append(f"    - {name}{count}")
         for name, ops_added_list, ops_removed_list in caps_changed:
-            b_count = len(before_caps[name] or [])
-            a_count = len(after_caps[name] or [])
+            b_count = len(((before_caps.get(name) or {}).get("operations") or []))
+            a_count = len(((after_caps.get(name) or {}).get("operations") or []))
             parts = []
             if ops_added_list:
                 parts.append(f"added: {', '.join(ops_added_list)}")
@@ -863,20 +1976,20 @@ def diff_reports(before: dict, after: dict) -> str:
             lines.append(f"    ~ {name}: {b_count} operations -> {a_count} operations{detail}")
         lines.append("")
 
-    has_any_change = (
-        added or removed or changed_risk
-        or res_added or res_removed or tmpl_added or tmpl_removed
-        or pr_added or pr_removed
-        or has_caps_diff
-    )
-    if not has_any_change:
+    if len(lines) <= 5 or lines[-1] != "":
+        # Ensure trailing newline and a clean end.
+        pass
+
+    # If nothing changed beyond header.
+    has_change_sections = any(h in lines for h in ("  Tools:", "  Resources:", "  Prompts:", "  Capabilities (manifest-declared):"))
+    if not has_change_sections:
         lines.append("  No changes detected.\n")
 
     return "\n".join(lines).rstrip() + "\n"
 
 
 def _report_json(report: dict) -> str:
-    """Serialize a report dict to a stable JSON string."""
+    """Serialize a snapshot dict to a stable JSON string (for storage/output)."""
     return json.dumps(report, indent=2, sort_keys=True) + "\n"
 
 
@@ -920,27 +2033,38 @@ def _read_captured_stderr(errbuf: TextIO | None) -> str:
     return errbuf.read().strip()
 
 
-def _postprocess_success(report: dict, server_err: str, *, verbose: bool) -> None:
+def _postprocess_success(snapshot: dict, server_err: str, *, verbose: bool) -> None:
     """
-    Post-process a successful inspect() report using captured stderr.
+    Post-process a successful inspect() snapshot using captured stderr.
 
-    Mutates ``report`` in place: merges stderr-derived notes, sets auth_gated status.
+    Mutates ``snapshot`` in place: merges stderr-derived notes, sets auth_gated status.
     """
     if server_err:
         notes, signals = stderr_notes(server_err)
         if notes:
-            report["notes"] = sorted(
-                (report.get("notes") or []) + notes,
+            obs = snapshot.get("observation") or {}
+            obs["notes"] = sorted(
+                (obs.get("notes") or []) + notes,
                 key=lambda n: (n.get("kind", ""), n.get("name", ""), n.get("rule", "")),
             )
+            snapshot["observation"] = obs
 
-        if signals.get("has_auth_hint") and (
-            not report.get("tools")
-            and not report.get("resources")
-            and not report.get("resourceTemplates")
-            and not report.get("prompts")
-        ):
-            report["status"] = "auth_gated"
+        # Auth-gated heuristic: stderr auth hint + empty declared surface.
+        if signals.get("has_auth_hint"):
+            surface = snapshot.get("surface") or {}
+            if (
+                not surface.get("tools")
+                and not surface.get("resources")
+                and not surface.get("resourceTemplates")
+                and not surface.get("prompts")
+            ):
+                obs = snapshot.get("observation") or {}
+                obs["status"] = "auth_gated"
+                snapshot["observation"] = obs
+                # Auth-gated surfaces are incomplete; do not emit a stable digest.
+                snapshot["surfaceCompleteness"] = "partial"
+                snapshot.pop("surfaceDigest", None)
+                snapshot.pop("surfaceEntityDigests", None)
 
     if verbose and server_err:
         sys.stderr.write("\n[server stderr]\n" + server_err + "\n")
@@ -985,19 +2109,27 @@ def _handle_inspect_failure(
     else:
         err_snippet = _normalize_text(str(exc))
 
-    report = _build_report(
+    generated_at = datetime.now(timezone.utc).isoformat()
+    coverage = {
+        "tools": {"declaredSupported": None, "attempted": False, "completed": False},
+        "resources": {"declaredSupported": None, "attempted": False, "completed": False},
+        "resourceTemplates": {"declaredSupported": None, "attempted": False, "completed": False},
+        "prompts": {"declaredSupported": None, "attempted": False, "completed": False},
+        "manifest": {"declaredSupported": None, "attempted": False, "completed": False},
+    }
+    snapshot = _build_snapshot(
+        generated_at=generated_at,
         scanned_command=[command, *args],
         server_name="unknown",
         protocol_version="unknown",
         capabilities={"tools": False, "resources": False, "prompts": False},
         status=status,
-        tools=[],
-        resource_uris=[],
-        template_uris=[],
-        prompts=[],
+        coverage=coverage,
+        surface={"tools": [], "resources": [], "resourceTemplates": [], "prompts": [], "declarationSources": []},
+        tools_for_text=[],
+        risk={"read": 0, "write": 0, "destructive": 0},
         signals=[],
         notes=stderr_notes_list,
-        risk={"read": 0, "write": 0, "destructive": 0},
         errors=[
             {
                 "kind": "mcp",
@@ -1021,7 +2153,7 @@ def _handle_inspect_failure(
     else:
         error_message = f"mcp-preflight: error: {_normalize_text(str(exc))}"
 
-    return report, error_message
+    return snapshot, error_message
 
 
 def _write_failure_stderr(server_err: str, *, verbose: bool, has_auth_hint: bool) -> None:
@@ -1040,7 +2172,7 @@ def _write_failure_stderr(server_err: str, *, verbose: bool, has_auth_hint: bool
 
 
 def _emit_report(report: dict, *, save_path: Path | None, as_json: bool) -> None:
-    """Save and/or print the JSON report."""
+    """Save and/or print the JSON snapshot."""
     if save_path:
         save_path.write_text(_report_json(report), encoding="utf-8")
     if as_json:

--- a/mcp_preflight.py
+++ b/mcp_preflight.py
@@ -2781,6 +2781,162 @@ def main() -> None:
             raise SystemExit(2)
         return
 
+    if sys.argv[1] == "check":
+        parser = argparse.ArgumentParser(prog="mcp-preflight check", add_help=True)
+        parser.add_argument("--json", action="store_true", dest="as_json", help="Print the check result as JSON")
+        parser.add_argument("--save", type=Path, help="Save the live snapshot (current) to a file")
+        parser.add_argument("--timeout", type=float, default=10.0, help="Timeout (seconds) for MCP calls (default: 10)")
+        parser.add_argument("--no-signals", action="store_true", help="Disable heuristic signal scanning/output")
+        parser.add_argument(
+            "--env",
+            action="append",
+            default=[],
+            help="Add/override an environment variable for the server (repeatable, KEY=VALUE)",
+        )
+        parser.add_argument("--cwd", type=Path, help="Working directory for the server process")
+        parser.add_argument(
+            "--home",
+            type=Path,
+            help="Set HOME for the server (also sets XDG_* dirs); equivalent to --env HOME=... with extras",
+        )
+        parser.add_argument(
+            "--isolate-home",
+            action="store_true",
+            help="Run server with HOME (and XDG_* dirs) set to a temporary directory",
+        )
+        vgroup = parser.add_mutually_exclusive_group()
+        vgroup.add_argument("--quiet", action="store_true", help="Suppress server stderr (even on failure)")
+        vgroup.add_argument("--verbose", action="store_true", help="Print server stderr (even on success)")
+        parser.add_argument("baseline", type=Path, help="Baseline snapshot JSON (must be a complete versioned snapshot)")
+        parser.add_argument("command", nargs=argparse.REMAINDER, help="Server command (quoted or split)")
+        ns = parser.parse_args(sys.argv[2:])
+
+        # Load and validate baseline.
+        try:
+            baseline_raw = json.loads(ns.baseline.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            sys.stderr.write(f"mcp-preflight check: error: invalid baseline JSON ({e})\n")
+            raise SystemExit(4)
+
+        if not (isinstance(baseline_raw, dict) and baseline_raw.get("snapshotFormatVersion")):
+            sys.stderr.write("mcp-preflight check: error: baseline must be a versioned snapshot (legacy reports are not supported)\n")
+            raise SystemExit(4)
+        ver = str(baseline_raw.get("snapshotFormatVersion"))
+        if ver != "1":
+            sys.stderr.write(f"mcp-preflight check: error: Unsupported snapshotFormatVersion: {ver}\n")
+            raise SystemExit(4)
+        if str(baseline_raw.get("surfaceCompleteness")) != "complete" or not baseline_raw.get("surfaceDigest"):
+            sys.stderr.write("mcp-preflight check: error: baseline must be a complete snapshot with surfaceDigest\n")
+            raise SystemExit(4)
+
+        if not ns.command:
+            sys.stderr.write("mcp-preflight check: error: missing server command\n")
+            raise SystemExit(2)
+
+        # Accept a single quoted command string or split args.
+        if len(ns.command) == 1:
+            parts = shlex.split(ns.command[0])
+        else:
+            parts = ns.command
+        if not parts:
+            sys.stderr.write("mcp-preflight check: error: missing server command\n")
+            raise SystemExit(2)
+
+        command = parts[0]
+        args = parts[1:]
+
+        server_env, temp_home_ctx = _build_server_env(ns)
+
+        errlog: TextIO
+        errbuf: TextIO | None = None
+        if ns.quiet:
+            errlog = open(os.devnull, "w")
+        else:
+            errbuf = tempfile.TemporaryFile(mode="w+", encoding="utf-8")
+            errlog = errbuf
+
+        current: dict | None = None
+        try:
+            current = asyncio.run(
+                inspect(
+                    command,
+                    args,
+                    timeout_s=ns.timeout,
+                    errlog=errlog,
+                    env=server_env,
+                    cwd=ns.cwd,
+                    include_signals=not ns.no_signals,
+                )
+            )
+
+            server_err = _read_captured_stderr(errbuf)
+            _postprocess_success(current, server_err, verbose=ns.verbose)
+        except BaseException as e:
+            server_err = _read_captured_stderr(errbuf)
+            _, stderr_flags = stderr_notes(server_err) if server_err else ([], {})
+            _write_failure_stderr(
+                server_err, verbose=ns.verbose, has_auth_hint=stderr_flags.get("has_auth_hint", False)
+            )
+            current, error_message = _handle_inspect_failure(
+                e, server_err=server_err, command=command, args=args, timeout_s=ns.timeout
+            )
+            sys.stderr.write(error_message + "\n")
+        finally:
+            try:
+                errlog.close()
+            except Exception:
+                pass
+            try:
+                if temp_home_ctx is not None:
+                    temp_home_ctx.cleanup()
+            except Exception:
+                pass
+
+        assert isinstance(current, dict)
+        if ns.save:
+            ns.save.write_text(_report_json(current), encoding="utf-8")
+
+        baseline_digest = str(baseline_raw.get("surfaceDigest"))
+        current_obs = current.get("observation") if isinstance(current.get("observation"), dict) else {}
+        current_status = str((current_obs or {}).get("status") or "")
+        current_digest = current.get("surfaceDigest")
+        current_complete = (str(current.get("surfaceCompleteness")) == "complete") and bool(current_digest)
+
+        identity_comparable = current_complete and current_status == "ok"
+        changed = False
+        exit_code = 0
+        if identity_comparable:
+            changed = (str(current_digest) != baseline_digest)
+            exit_code = 1 if changed else 0
+        else:
+            # Non-ok statuses are inspection failures (2), while "partial" is incomparable (3).
+            if current_status == "partial":
+                exit_code = 3
+            else:
+                exit_code = 2
+
+        if ns.as_json:
+            result = {
+                "baseline": {"path": str(ns.baseline), "surfaceDigest": baseline_digest},
+                "current": {
+                    "surfaceDigest": current_digest,
+                    "surfaceCompleteness": current.get("surfaceCompleteness"),
+                    "status": (current_obs or {}).get("status"),
+                },
+                "identityComparable": identity_comparable,
+                "changed": changed if identity_comparable else None,
+                "exitCode": exit_code,
+            }
+            if identity_comparable:
+                result["changes"] = _compute_surface_changes(baseline_raw.get("surface") or {}, current.get("surface") or {})
+            else:
+                result["comparison"] = _compute_snapshot_comparison(baseline_raw, current)
+            sys.stdout.write(json.dumps(result, indent=2, sort_keys=True) + "\n")
+        else:
+            sys.stdout.write(diff_reports(baseline_raw, current))
+
+        raise SystemExit(exit_code)
+
     parser = argparse.ArgumentParser(
         prog="mcp-preflight",
         add_help=True,

--- a/mcp_preflight.py
+++ b/mcp_preflight.py
@@ -28,6 +28,8 @@ from typing import Any, TextIO
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
+__version__ = "0.3.0"
+
 # Exception groups are built-in in Python 3.11+, but on 3.10 they're provided by the
 # `exceptiongroup` backport (often installed as a transitive dependency).
 try:  # Python 3.11+
@@ -1659,6 +1661,338 @@ def _compute_surface_changes(before_surface: dict, after_surface: dict) -> list[
     return changes
 
 
+def _snapshot_comparison_metadata(snap: dict) -> dict:
+    obs = snap.get("observation") if isinstance(snap, dict) else None
+    if not isinstance(obs, dict):
+        return {}
+    cm = obs.get("comparisonMetadata")
+    return cm if isinstance(cm, dict) else {}
+
+
+def _snapshot_is_legacy(snap: dict) -> bool:
+    cm = _snapshot_comparison_metadata(snap)
+    return bool(cm.get("legacy"))
+
+
+def _snapshot_has_evidence_gap(snap: dict, *, entity_type: str, path: str) -> bool:
+    cm = _snapshot_comparison_metadata(snap)
+    gaps = cm.get("evidenceGaps")
+    if not isinstance(gaps, list):
+        return False
+    for g in gaps:
+        if not isinstance(g, dict):
+            continue
+        if g.get("entityType") != entity_type:
+            continue
+
+        # Explicit per-path list.
+        gpaths = g.get("paths")
+        if isinstance(gpaths, list) and all(isinstance(p, str) for p in gpaths):
+            if path in gpaths:
+                return True
+
+        # Regex-style matcher for semantic paths.
+        pat = g.get("pathPattern")
+        if isinstance(pat, str) and pat:
+            try:
+                if re.match(pat, path):
+                    return True
+            except re.error:
+                # Ignore invalid patterns; treat as non-match.
+                pass
+
+        gpath = g.get("path")
+        if not isinstance(gpath, str) or not gpath:
+            continue
+        if gpath == "*" or gpath == path:
+            return True
+        if gpath.endswith("/*") and path.startswith(gpath[:-1]):
+            return True
+    return False
+
+
+def _compute_snapshot_comparison(before_snapshot: dict, after_snapshot: dict) -> dict:
+    """
+    Snapshot-level comparison wrapper.
+
+    For complete-vs-complete, identityComparable is True and changes come straight from
+    _compute_surface_changes().
+
+    If either side is legacy or partial, identityComparable is False and we:
+    - report limitations
+    - suppress changes that are not comparable due to evidence gaps
+    - emit evidenceChanges (e.g. newly observable tool schemas)
+    """
+    b = before_snapshot if isinstance(before_snapshot, dict) else {}
+    a = after_snapshot if isinstance(after_snapshot, dict) else {}
+    b_surface = b.get("surface") if isinstance(b.get("surface"), dict) else {}
+    a_surface = a.get("surface") if isinstance(a.get("surface"), dict) else {}
+
+    b_comp = b.get("surfaceCompleteness", "partial")
+    a_comp = a.get("surfaceCompleteness", "partial")
+    b_digest = b.get("surfaceDigest")
+    a_digest = a.get("surfaceDigest")
+    b_legacy = _snapshot_is_legacy(b)
+    a_legacy = _snapshot_is_legacy(a)
+
+    identity_comparable = bool(
+        (b_comp == "complete")
+        and (a_comp == "complete")
+        and bool(b_digest)
+        and bool(a_digest)
+        and not b_legacy
+        and not a_legacy
+    )
+
+    limitations: list[dict] = []
+    if not identity_comparable:
+        limitations.append(
+            {
+                "type": "identity_unavailable",
+                "message": "Complete-surface identity comparison is unavailable (legacy and/or partial snapshot involved).",
+            }
+        )
+
+    if b_legacy:
+        limitations.append(
+            {
+                "type": "legacy_format",
+                "side": "before",
+                "message": "Before snapshot was converted from a legacy report format; some evidence was not captured.",
+            }
+        )
+    if a_legacy:
+        limitations.append(
+            {
+                "type": "legacy_format",
+                "side": "after",
+                "message": "After snapshot was converted from a legacy report format; some evidence was not captured.",
+            }
+        )
+
+    def _coverage_limitations(snap: dict, *, side: str) -> tuple[list[dict], set[str]]:
+        obs = snap.get("observation")
+        if not isinstance(obs, dict):
+            return [], set()
+        cov = obs.get("coverage")
+        if not isinstance(cov, dict):
+            return [], set()
+        out: list[dict] = []
+        incomplete_sections: set[str] = set()
+        for section in sorted(cov.keys()):
+            entry = cov.get(section)
+            if not isinstance(entry, dict):
+                continue
+            attempted = entry.get("attempted")
+            completed = entry.get("completed")
+            if attempted is True and completed is False:
+                rule = entry.get("errorRule") or "incomplete"
+                incomplete_sections.add(str(section))
+                out.append(
+                    {
+                        "type": "coverage_incomplete",
+                        "side": side,
+                        "section": section,
+                        "errorRule": rule,
+                        "reason": rule,
+                        "message": f"{side.capitalize()} snapshot did not complete {section} inspection ({rule}).",
+                    }
+                )
+        return out, incomplete_sections
+
+    b_incomplete_sections: set[str] = set()
+    a_incomplete_sections: set[str] = set()
+    if b_comp != "complete":
+        lim, secs = _coverage_limitations(b, side="before")
+        limitations.extend(lim)
+        b_incomplete_sections |= secs
+    if a_comp != "complete":
+        lim, secs = _coverage_limitations(a, side="after")
+        limitations.extend(lim)
+        a_incomplete_sections |= secs
+
+    # Evidence-gap limitations (known legacy format omissions).
+    if _snapshot_has_evidence_gap(b, entity_type="tool", path="/inputSchema"):
+        limitations.append(
+            {
+                "type": "evidence_gap",
+                "side": "before",
+                "entityType": "tool",
+                "path": "/inputSchema",
+                "message": "Tool input schemas were not captured by the legacy report format (before side).",
+            }
+        )
+    if _snapshot_has_evidence_gap(a, entity_type="tool", path="/inputSchema"):
+        limitations.append(
+            {
+                "type": "evidence_gap",
+                "side": "after",
+                "entityType": "tool",
+                "path": "/inputSchema",
+                "message": "Tool input schemas were not captured by the legacy report format (after side).",
+            }
+        )
+    if _snapshot_has_evidence_gap(b, entity_type="resource", path="/description"):
+        limitations.append(
+            {
+                "type": "evidence_gap",
+                "side": "before",
+                "entityType": "resource",
+                "paths": ["/name", "/title", "/description", "/mimeType", "/annotations"],
+                "message": "Resource metadata fields were not captured by the legacy report format (before side).",
+            }
+        )
+    if _snapshot_has_evidence_gap(a, entity_type="resource", path="/description"):
+        limitations.append(
+            {
+                "type": "evidence_gap",
+                "side": "after",
+                "entityType": "resource",
+                "paths": ["/name", "/title", "/description", "/mimeType", "/annotations"],
+                "message": "Resource metadata fields were not captured by the legacy report format (after side).",
+            }
+        )
+    if _snapshot_has_evidence_gap(b, entity_type="resource_template", path="/description"):
+        limitations.append(
+            {
+                "type": "evidence_gap",
+                "side": "before",
+                "entityType": "resource_template",
+                "paths": ["/name", "/title", "/description", "/mimeType", "/annotations"],
+                "message": "Resource-template metadata fields were not captured by the legacy report format (before side).",
+            }
+        )
+    if _snapshot_has_evidence_gap(a, entity_type="resource_template", path="/description"):
+        limitations.append(
+            {
+                "type": "evidence_gap",
+                "side": "after",
+                "entityType": "resource_template",
+                "paths": ["/name", "/title", "/description", "/mimeType", "/annotations"],
+                "message": "Resource-template metadata fields were not captured by the legacy report format (after side).",
+            }
+        )
+    if _snapshot_has_evidence_gap(b, entity_type="prompt", path="/arguments/x/required"):
+        limitations.append(
+            {
+                "type": "evidence_gap",
+                "side": "before",
+                "entityType": "prompt",
+                "pathPattern": r"^/arguments/[^/]+/(description|required|schema)$",
+                "message": "Prompt argument details were not captured by the legacy report format (before side).",
+            }
+        )
+    if _snapshot_has_evidence_gap(a, entity_type="prompt", path="/arguments/x/required"):
+        limitations.append(
+            {
+                "type": "evidence_gap",
+                "side": "after",
+                "entityType": "prompt",
+                "pathPattern": r"^/arguments/[^/]+/(description|required|schema)$",
+                "message": "Prompt argument details were not captured by the legacy report format (after side).",
+            }
+        )
+
+    changes = _compute_surface_changes(b_surface, a_surface)
+
+    # If either side did not complete inspection for a surface section, suppress changes for
+    # entity types owned by that section. This prevents "unknown" from being rendered as
+    # add/remove/change.
+    section_to_entity_types = {
+        "tools": {"tool"},
+        "resources": {"resource"},
+        "resourceTemplates": {"resource_template"},
+        "prompts": {"prompt"},
+        "manifest": {"manifest_tool"},
+    }
+    suppressed_entity_types: set[str] = set()
+    for sec in (b_incomplete_sections | a_incomplete_sections):
+        suppressed_entity_types |= section_to_entity_types.get(str(sec), set())
+    if suppressed_entity_types:
+        changes = [c for c in changes if c.get("entityType") not in suppressed_entity_types]
+
+    evidence_changes: list[dict] = []
+    tool_schema_gap_before = _snapshot_has_evidence_gap(b, entity_type="tool", path="/inputSchema")
+    tool_schema_gap_after = _snapshot_has_evidence_gap(a, entity_type="tool", path="/inputSchema")
+    if tool_schema_gap_before or tool_schema_gap_after:
+        # Suppress tool inputSchema changes when one side lacks schema evidence.
+        filtered: list[dict] = []
+        for c in changes:
+            if (
+                c.get("type") == "value_changed"
+                and c.get("entityType") == "tool"
+                and c.get("path") == "/inputSchema"
+                and (tool_schema_gap_before or tool_schema_gap_after)
+            ):
+                continue
+            filtered.append(c)
+        changes = filtered
+
+        # Emit observability changes for tool schemas.
+        b_tools = {t.get("name"): t for t in (b_surface.get("tools") or []) if isinstance(t, dict) and t.get("name")}
+        a_tools = {t.get("name"): t for t in (a_surface.get("tools") or []) if isinstance(t, dict) and t.get("name")}
+        common = sorted(set(b_tools) & set(a_tools))
+        for name in common:
+            bt = b_tools.get(name) or {}
+            at = a_tools.get(name) or {}
+            b_schema_present = bt.get("inputSchema") is not None
+            a_schema_present = at.get("inputSchema") is not None
+            if tool_schema_gap_before and a_schema_present:
+                evidence_changes.append(
+                    {
+                        "type": "field_became_observable",
+                        "entityType": "tool",
+                        "entityId": str(name),
+                        "path": "/inputSchema",
+                        "message": "Tool input schema became observable (legacy report did not capture schemas).",
+                    }
+                )
+            if tool_schema_gap_after and b_schema_present:
+                evidence_changes.append(
+                    {
+                        "type": "field_became_unobservable",
+                        "entityType": "tool",
+                        "entityId": str(name),
+                        "path": "/inputSchema",
+                        "message": "Tool input schema became unobservable (legacy report did not capture schemas).",
+                    }
+                )
+
+    # Suppress non-comparable change records for known evidence gaps. (This doesn't affect the current
+    # text renderer directly, but keeps the comparison model honest for future machine output.)
+    if _snapshot_has_evidence_gap(b, entity_type="resource", path="/description") or _snapshot_has_evidence_gap(a, entity_type="resource", path="/description"):
+        changes = [c for c in changes if not (c.get("entityType") == "resource" and c.get("type") == "value_changed")]
+    if _snapshot_has_evidence_gap(b, entity_type="resource_template", path="/description") or _snapshot_has_evidence_gap(a, entity_type="resource_template", path="/description"):
+        changes = [c for c in changes if not (c.get("entityType") == "resource_template" and c.get("type") == "value_changed")]
+    prompt_arg_details_gap = _snapshot_has_evidence_gap(b, entity_type="prompt", path="/arguments/x/required") or _snapshot_has_evidence_gap(
+        a, entity_type="prompt", path="/arguments/x/required"
+    )
+    if prompt_arg_details_gap:
+        # Only suppress nested arg-detail fields, not arg-name add/remove.
+        # (value_added/value_removed at /arguments/<arg> remain comparable)
+        arg_detail_pat = re.compile(r"^/arguments/[^/]+/(description|required|schema)$")
+        filtered_changes: list[dict] = []
+        for c in changes:
+            if c.get("entityType") != "prompt":
+                filtered_changes.append(c)
+                continue
+            p = c.get("path")
+            if isinstance(p, str) and arg_detail_pat.match(p):
+                continue
+            filtered_changes.append(c)
+        changes = filtered_changes
+
+    evidence_changes.sort(key=lambda r: (r.get("entityType", ""), r.get("entityId", ""), r.get("type", ""), r.get("path", "")))
+    limitations.sort(key=lambda r: (r.get("type", ""), r.get("side", ""), r.get("entityType", ""), r.get("path", "")))
+
+    return {
+        "identityComparable": identity_comparable,
+        "limitations": limitations,
+        "changes": changes,
+        "evidenceChanges": evidence_changes,
+    }
+
+
 def diff_reports(before: dict, after: dict) -> str:
     SUPPORTED_SNAPSHOT_FORMATS = {"1"}
 
@@ -1731,6 +2065,38 @@ def diff_reports(before: dict, after: dict) -> str:
             notes=notes,
             errors=errors,
         )
+        # Add evidence-gap metadata without changing surface semantics.
+        snap_obs = snap.get("observation")
+        if isinstance(snap_obs, dict):
+            snap_obs["comparisonMetadata"] = {
+                "legacy": True,
+                "evidenceGaps": [
+                    {
+                        "type": "field_not_captured",
+                        "entityType": "tool",
+                        "path": "/inputSchema",
+                        "reason": "legacy_format_not_captured",
+                    },
+                    {
+                        "type": "fields_not_captured",
+                        "entityType": "resource",
+                        "paths": ["/name", "/title", "/description", "/mimeType", "/annotations"],
+                        "reason": "legacy_format_only_uris",
+                    },
+                    {
+                        "type": "fields_not_captured",
+                        "entityType": "resource_template",
+                        "paths": ["/name", "/title", "/description", "/mimeType", "/annotations"],
+                        "reason": "legacy_format_only_uri_templates",
+                    },
+                    {
+                        "type": "fields_not_captured",
+                        "entityType": "prompt",
+                        "pathPattern": r"^/arguments/[^/]+/(description|required|schema)$",
+                        "reason": "legacy_format_argument_details_not_captured",
+                    },
+                ],
+            }
         # Force legacy conversion to partial regardless of coverage heuristics.
         snap["surfaceCompleteness"] = "partial"
         snap.pop("surfaceDigest", None)
@@ -1777,8 +2143,134 @@ def diff_reports(before: dict, after: dict) -> str:
         lines.append(f"\n  surfaceDigest:\n    before: {b_digest}\n    after:  {a_digest}\n")
     else:
         lines.append("")
-        if b_comp != "complete" or a_comp != "complete":
-            lines.append("  Note: surfaceDigest is omitted unless both surfaces are complete.\n")
+        # No digest comparison shown unless both snapshots are complete; see identityComparable below.
+
+    comparison = _compute_snapshot_comparison(b, a)
+    identity_comparable = bool(comparison.get("identityComparable"))
+    limitations = comparison.get("limitations") if isinstance(comparison.get("limitations"), list) else []
+    evidence_changes = comparison.get("evidenceChanges") if isinstance(comparison.get("evidenceChanges"), list) else []
+    tool_schema_incomparable = any(
+        isinstance(l, dict) and l.get("type") == "evidence_gap" and l.get("entityType") == "tool" and l.get("path") == "/inputSchema"
+        for l in limitations
+    )
+    resource_meta_incomparable = any(
+        isinstance(l, dict)
+        and l.get("type") == "evidence_gap"
+        and l.get("entityType") == "resource"
+        and (l.get("path") == "*" or isinstance(l.get("paths"), list))
+        for l in limitations
+    )
+    template_meta_incomparable = any(
+        isinstance(l, dict)
+        and l.get("type") == "evidence_gap"
+        and l.get("entityType") == "resource_template"
+        and (l.get("path") == "*" or isinstance(l.get("paths"), list))
+        for l in limitations
+    )
+    prompt_arg_details_incomparable = any(
+        isinstance(l, dict)
+        and l.get("type") == "evidence_gap"
+        and l.get("entityType") == "prompt"
+        and (str(l.get("path")) in ("/arguments/*", "/arguments") or isinstance(l.get("pathPattern"), str))
+        for l in limitations
+    )
+    incomplete_sections: set[str] = set(
+        str(l.get("section"))
+        for l in limitations
+        if isinstance(l, dict) and l.get("type") == "coverage_incomplete" and l.get("section")
+    )
+    tools_incomparable = "tools" in incomplete_sections
+    resources_incomparable = "resources" in incomplete_sections
+    templates_incomparable = "resourceTemplates" in incomplete_sections
+    prompts_incomparable = "prompts" in incomplete_sections
+    manifest_incomparable = "manifest" in incomplete_sections
+
+    if not identity_comparable:
+        lines.append("  Complete-surface identity comparison: unavailable")
+        lines.append("")
+
+        def _format_limitations(raw: list[object]) -> list[str]:
+            # Drop the redundant structured limitation; we already render the identity-unavailable line above.
+            lims = [l for l in raw if isinstance(l, dict) and l.get("type") != "identity_unavailable"]
+            if not lims:
+                return []
+
+            def side_label(side: object) -> str:
+                return "Before" if side == "before" else ("After" if side == "after" else "Unknown")
+
+            def base_key(l: dict) -> tuple:
+                t = l.get("type")
+                if t == "coverage_incomplete":
+                    return (t, l.get("section"), l.get("reason"), l.get("side"))
+                if t == "legacy_format":
+                    return (t,)
+                if t == "evidence_gap":
+                    return (t, l.get("entityType"), l.get("path"), tuple(l.get("paths") or []), l.get("pathPattern"))
+                return (t, json.dumps(l, sort_keys=True, ensure_ascii=False))
+
+            grouped: dict[tuple, list[dict]] = {}
+            for l in lims:
+                grouped.setdefault(base_key(l), []).append(l)
+
+            out: list[str] = []
+            for k in sorted(grouped.keys(), key=lambda x: str(x)):
+                items = grouped[k]
+                t = items[0].get("type")
+                sides = sorted({i.get("side") for i in items if i.get("side") in ("before", "after")})
+
+                def with_sides(msg: str) -> str:
+                    if sides == ["before"]:
+                        return f"Before snapshot: {msg}"
+                    if sides == ["after"]:
+                        return f"After snapshot: {msg}"
+                    if sides == ["before", "after"]:
+                        return f"Both snapshots: {msg}"
+                    return msg
+
+                if t == "legacy_format":
+                    out.append(with_sides("uses the legacy report format; some evidence was not captured."))
+                    continue
+
+                if t == "coverage_incomplete":
+                    # Preserve side/section specificity; different failures shouldn't be collapsed.
+                    i = items[0]
+                    sec = i.get("section")
+                    reason = i.get("reason") or i.get("errorRule") or "incomplete"
+                    side = i.get("side")
+                    out.append(f"{side_label(side)} snapshot did not complete {sec} inspection ({reason}).")
+                    continue
+
+                if t == "evidence_gap":
+                    i = items[0]
+                    et = i.get("entityType")
+                    if et == "tool" and i.get("path") == "/inputSchema":
+                        out.append(with_sides("tool input schemas were not captured."))
+                        continue
+                    if et == "resource":
+                        out.append(with_sides("resource metadata were not captured."))
+                        continue
+                    if et == "resource_template":
+                        out.append(with_sides("resource-template metadata were not captured."))
+                        continue
+                    if et == "prompt":
+                        out.append(with_sides("prompt argument details beyond argument names were not captured."))
+                        continue
+
+                # Fallback to the existing message if present.
+                msg = items[0].get("message")
+                if isinstance(msg, str) and msg:
+                    out.append(msg)
+                else:
+                    out.append(json.dumps(items[0], ensure_ascii=False))
+
+            return out
+
+        formatted_limitations = _format_limitations(limitations)
+        if formatted_limitations:
+            lines.append("  Comparison limitations:")
+            for msg in formatted_limitations:
+                lines.append(f"    - {msg}")
+            lines.append("")
 
     def tool_map(surface: dict) -> dict[str, dict]:
         out: dict[str, dict] = {}
@@ -1847,137 +2339,212 @@ def diff_reports(before: dict, after: dict) -> str:
             out_lines.append(f"    ~ {p}: {json.dumps(x, ensure_ascii=False)[:160]} -> {json.dumps(y, ensure_ascii=False)[:160]}")
 
     # Tools
-    b_tools = tool_map(b_can)
-    a_tools = tool_map(a_can)
-    t_added = sorted(set(a_tools) - set(b_tools))
-    t_removed = sorted(set(b_tools) - set(a_tools))
-    t_common = sorted(set(b_tools) & set(a_tools))
-    tool_changes: list[str] = []
-    for name in t_common:
-        bt = b_tools[name]
-        at = a_tools[name]
-        if (bt.get("description") or "") != (at.get("description") or ""):
-            tool_changes.append(f"    ~ {name}.description")
-        if _canonical_json_bytes(bt.get("inputSchema")) != _canonical_json_bytes(at.get("inputSchema")):
-            tool_changes.append(f"    ~ {name}.inputSchema")
-
-    if t_added or t_removed or tool_changes:
-        lines.append("  Tools:")
-        for n in t_added:
-            lines.append(f"    + {n}")
-        for n in t_removed:
-            lines.append(f"    - {n}")
-        # Expand per-tool structural diffs for changed tools (bounded).
+    if not tools_incomparable:
+        b_tools = tool_map(b_can)
+        a_tools = tool_map(a_can)
+        t_added = sorted(set(a_tools) - set(b_tools))
+        t_removed = sorted(set(b_tools) - set(a_tools))
+        t_common = sorted(set(b_tools) & set(a_tools))
+        tool_changes: list[str] = []
         for name in t_common:
             bt = b_tools[name]
             at = a_tools[name]
             if (bt.get("description") or "") != (at.get("description") or ""):
-                lines.append(f"    ~ {name}.description: {json.dumps(bt.get('description'), ensure_ascii=False)} -> {json.dumps(at.get('description'), ensure_ascii=False)}")
-            b_schema = bt.get("inputSchema")
-            a_schema = at.get("inputSchema")
-            if _canonical_json_bytes(b_schema) != _canonical_json_bytes(a_schema):
-                lines.append(f"    ~ {name}.inputSchema:")
-                diff_values(f"{name}.inputSchema", b_schema, a_schema, lines, limit=25)
-        lines.append("")
+                tool_changes.append(f"    ~ {name}.description")
+            if not tool_schema_incomparable:
+                if _canonical_json_bytes(bt.get("inputSchema")) != _canonical_json_bytes(at.get("inputSchema")):
+                    tool_changes.append(f"    ~ {name}.inputSchema")
+
+        if t_added or t_removed or tool_changes:
+            lines.append("  Tools:")
+            for n in t_added:
+                lines.append(f"    + {n}")
+            for n in t_removed:
+                lines.append(f"    - {n}")
+            # Expand per-tool structural diffs for changed tools (bounded).
+            for name in t_common:
+                bt = b_tools[name]
+                at = a_tools[name]
+                if (bt.get("description") or "") != (at.get("description") or ""):
+                    lines.append(f"    ~ {name}.description: {json.dumps(bt.get('description'), ensure_ascii=False)} -> {json.dumps(at.get('description'), ensure_ascii=False)}")
+                if not tool_schema_incomparable:
+                    b_schema = bt.get("inputSchema")
+                    a_schema = at.get("inputSchema")
+                    if _canonical_json_bytes(b_schema) != _canonical_json_bytes(a_schema):
+                        lines.append(f"    ~ {name}.inputSchema:")
+                        diff_values(f"{name}.inputSchema", b_schema, a_schema, lines, limit=25)
+            lines.append("")
 
     # Resources / templates
-    b_res = map_by(b_can.get("resources") or [], "uri")
-    a_res = map_by(a_can.get("resources") or [], "uri")
-    b_tmpl = map_by(b_can.get("resourceTemplates") or [], "uriTemplate")
-    a_tmpl = map_by(a_can.get("resourceTemplates") or [], "uriTemplate")
-    res_added = sorted(set(a_res) - set(b_res))
-    res_removed = sorted(set(b_res) - set(a_res))
-    res_common = sorted(set(b_res) & set(a_res))
-    res_changed = [u for u in res_common if b_res[u] != a_res[u]]
-    tmpl_added = sorted(set(a_tmpl) - set(b_tmpl))
-    tmpl_removed = sorted(set(b_tmpl) - set(a_tmpl))
-    tmpl_common = sorted(set(b_tmpl) & set(a_tmpl))
-    tmpl_changed = [u for u in tmpl_common if b_tmpl[u] != a_tmpl[u]]
-    if res_added or res_removed or res_changed or tmpl_added or tmpl_removed or tmpl_changed:
-        lines.append("  Resources:")
-        for u in res_added:
-            lines.append(f"    + {u}")
-        for u in res_removed:
-            lines.append(f"    - {u}")
-        for u in res_changed:
-            lines.append(f"    ~ {u}")
-        for u in tmpl_added:
-            lines.append(f"    + {u}")
-        for u in tmpl_removed:
-            lines.append(f"    - {u}")
-        for u in tmpl_changed:
-            lines.append(f"    ~ {u}")
-        lines.append("")
+    if not resources_incomparable and not templates_incomparable:
+        b_res = map_by(b_can.get("resources") or [], "uri")
+        a_res = map_by(a_can.get("resources") or [], "uri")
+        b_tmpl = map_by(b_can.get("resourceTemplates") or [], "uriTemplate")
+        a_tmpl = map_by(a_can.get("resourceTemplates") or [], "uriTemplate")
+        res_added = sorted(set(a_res) - set(b_res))
+        res_removed = sorted(set(b_res) - set(a_res))
+        res_common = sorted(set(b_res) & set(a_res))
+        if resource_meta_incomparable:
+            res_changed = []
+        else:
+            res_changed = [u for u in res_common if b_res[u] != a_res[u]]
+        tmpl_added = sorted(set(a_tmpl) - set(b_tmpl))
+        tmpl_removed = sorted(set(b_tmpl) - set(a_tmpl))
+        tmpl_common = sorted(set(b_tmpl) & set(a_tmpl))
+        if template_meta_incomparable:
+            tmpl_changed = []
+        else:
+            tmpl_changed = [u for u in tmpl_common if b_tmpl[u] != a_tmpl[u]]
+        if res_added or res_removed or res_changed or tmpl_added or tmpl_removed or tmpl_changed:
+            lines.append("  Resources:")
+            for u in res_added:
+                lines.append(f"    + {u}")
+            for u in res_removed:
+                lines.append(f"    - {u}")
+            for u in res_changed:
+                lines.append(f"    ~ {u}")
+            for u in tmpl_added:
+                lines.append(f"    + {u}")
+            for u in tmpl_removed:
+                lines.append(f"    - {u}")
+            for u in tmpl_changed:
+                lines.append(f"    ~ {u}")
+            lines.append("")
 
     # Prompts
-    b_prompts = prompt_map(b_can)
-    a_prompts = prompt_map(a_can)
-    p_added = sorted(set(a_prompts) - set(b_prompts))
-    p_removed = sorted(set(b_prompts) - set(a_prompts))
-    p_common = sorted(set(b_prompts) & set(a_prompts))
-    p_changed: list[str] = []
-    for name in p_common:
-        bp = b_prompts[name]
-        ap = a_prompts[name]
-        if bp != ap:
-            p_changed.append(name)
-    if p_added or p_removed or p_changed:
-        lines.append("  Prompts:")
-        for n in p_added:
-            lines.append(f"    + {n}")
-        for n in p_removed:
-            lines.append(f"    - {n}")
-        for n in p_changed:
-            lines.append(f"    ~ {n}")
-        lines.append("")
+    if not prompts_incomparable:
+        b_prompts = prompt_map(b_can)
+        a_prompts = prompt_map(a_can)
+        p_added = sorted(set(a_prompts) - set(b_prompts))
+        p_removed = sorted(set(b_prompts) - set(a_prompts))
+        p_common = sorted(set(b_prompts) & set(a_prompts))
+        p_changed: list[str] = []
+        p_desc_changed: dict[str, tuple[Any, Any]] = {}
+        p_args_changed: dict[str, tuple[list[str], list[str]]] = {}
+        for name in p_common:
+            bp = b_prompts[name]
+            ap = a_prompts[name]
+            if prompt_arg_details_incomparable:
+                b_args = sorted([a.get("name") for a in (bp.get("arguments") or []) if isinstance(a, dict) and a.get("name")])
+                a_args = sorted([a.get("name") for a in (ap.get("arguments") or []) if isinstance(a, dict) and a.get("name")])
+                if bp.get("description") != ap.get("description"):
+                    p_desc_changed[name] = (bp.get("description"), ap.get("description"))
+                if b_args != a_args:
+                    added = sorted(set(a_args) - set(b_args))
+                    removed = sorted(set(b_args) - set(a_args))
+                    p_args_changed[name] = (added, removed)
+                if (bp.get("description") != ap.get("description")) or (b_args != a_args):
+                    p_changed.append(name)
+            else:
+                if bp != ap:
+                    if bp.get("description") != ap.get("description"):
+                        p_desc_changed[name] = (bp.get("description"), ap.get("description"))
+                    b_args = sorted([a.get("name") for a in (bp.get("arguments") or []) if isinstance(a, dict) and a.get("name")])
+                    a_args = sorted([a.get("name") for a in (ap.get("arguments") or []) if isinstance(a, dict) and a.get("name")])
+                    if b_args != a_args:
+                        added = sorted(set(a_args) - set(b_args))
+                        removed = sorted(set(b_args) - set(a_args))
+                        p_args_changed[name] = (added, removed)
+                    p_changed.append(name)
+        if p_added or p_removed or p_changed:
+            lines.append("  Prompts:")
+            for n in p_added:
+                lines.append(f"    + {n}")
+            for n in p_removed:
+                lines.append(f"    - {n}")
+            for n in p_changed:
+                rendered_any_detail = False
+                if n in p_desc_changed:
+                    before_desc, after_desc = p_desc_changed[n]
+                    lines.append(f"    ~ {n}.description:")
+                    lines.append(
+                        f"        {json.dumps(before_desc, ensure_ascii=False)} -> {json.dumps(after_desc, ensure_ascii=False)}"
+                    )
+                    rendered_any_detail = True
+                if n in p_args_changed:
+                    added, removed = p_args_changed[n]
+                    lines.append(f"    ~ {n}.arguments:")
+                    if added:
+                        lines.append(f"        added: {', '.join(added)}")
+                    if removed:
+                        lines.append(f"        removed: {', '.join(removed)}")
+                    rendered_any_detail = True
+                if not rendered_any_detail:
+                    lines.append(f"    ~ {n}")
+            lines.append("")
 
     # Manifest / action-level capability diff (from declarationSources).
-    before_caps = _manifest_tool_caps_entry_map_from_surface(b_can)
-    after_caps = _manifest_tool_caps_entry_map_from_surface(a_can)
-    caps_added = sorted(set(after_caps) - set(before_caps))
-    caps_removed = sorted(set(before_caps) - set(after_caps))
-    caps_changed: list[tuple[str, list[str], list[str]]] = []
-    for name in sorted(set(before_caps) & set(after_caps)):
-        be = before_caps.get(name) or {}
-        ae = after_caps.get(name) or {}
-        b_ops_raw = be.get("operations") or []
-        a_ops_raw = ae.get("operations") or []
-        try:
-            b_ops = set(b_ops_raw)
-            a_ops = set(a_ops_raw)
-        except TypeError:
-            # If operations aren't hashable, fall back to whole-list comparison.
-            if b_ops_raw != a_ops_raw:
-                caps_changed.append((name, [], []))
-            continue
-        # If any identity-bearing manifest metadata changed, treat as a manifest change.
-        if be != ae:
-            ops_added = sorted(a_ops - b_ops)
-            ops_removed = sorted(b_ops - a_ops)
-            caps_changed.append((name, ops_added, ops_removed))
+    if not manifest_incomparable:
+        before_caps = _manifest_tool_caps_entry_map_from_surface(b_can)
+        after_caps = _manifest_tool_caps_entry_map_from_surface(a_can)
+        caps_added = sorted(set(after_caps) - set(before_caps))
+        caps_removed = sorted(set(before_caps) - set(after_caps))
+        caps_changed: list[tuple[str, list[str], list[str]]] = []
+        for name in sorted(set(before_caps) & set(after_caps)):
+            be = before_caps.get(name) or {}
+            ae = after_caps.get(name) or {}
+            b_ops_raw = be.get("operations") or []
+            a_ops_raw = ae.get("operations") or []
+            try:
+                b_ops = set(b_ops_raw)
+                a_ops = set(a_ops_raw)
+            except TypeError:
+                # If operations aren't hashable, fall back to whole-list comparison.
+                if b_ops_raw != a_ops_raw:
+                    caps_changed.append((name, [], []))
+                continue
+            # If any identity-bearing manifest metadata changed, treat as a manifest change.
+            if be != ae:
+                ops_added = sorted(a_ops - b_ops)
+                ops_removed = sorted(b_ops - a_ops)
+                caps_changed.append((name, ops_added, ops_removed))
 
-    has_caps_diff = caps_added or caps_removed or caps_changed
-    if has_caps_diff:
-        lines.append("  Capabilities (manifest-declared):")
-        for name in caps_added:
-            ops = (after_caps.get(name) or {}).get("operations")
-            count = f" ({len(ops)} operations)" if ops else ""
-            lines.append(f"    + {name}{count}")
-        for name in caps_removed:
-            ops = (before_caps.get(name) or {}).get("operations")
-            count = f" ({len(ops)} operations)" if ops else ""
-            lines.append(f"    - {name}{count}")
-        for name, ops_added_list, ops_removed_list in caps_changed:
-            b_count = len(((before_caps.get(name) or {}).get("operations") or []))
-            a_count = len(((after_caps.get(name) or {}).get("operations") or []))
-            parts = []
-            if ops_added_list:
-                parts.append(f"added: {', '.join(ops_added_list)}")
-            if ops_removed_list:
-                parts.append(f"removed: {', '.join(ops_removed_list)}")
-            detail = f" ({'; '.join(parts)})" if parts else ""
-            lines.append(f"    ~ {name}: {b_count} operations -> {a_count} operations{detail}")
-        lines.append("")
+        has_caps_diff = caps_added or caps_removed or caps_changed
+        if has_caps_diff:
+            lines.append("  Capabilities (manifest-declared):")
+            for name in caps_added:
+                ops = (after_caps.get(name) or {}).get("operations")
+                count = f" ({len(ops)} operations)" if ops else ""
+                lines.append(f"    + {name}{count}")
+            for name in caps_removed:
+                ops = (before_caps.get(name) or {}).get("operations")
+                count = f" ({len(ops)} operations)" if ops else ""
+                lines.append(f"    - {name}{count}")
+            for name, ops_added_list, ops_removed_list in caps_changed:
+                b_count = len(((before_caps.get(name) or {}).get("operations") or []))
+                a_count = len(((after_caps.get(name) or {}).get("operations") or []))
+                parts = []
+                if ops_added_list:
+                    parts.append(f"added: {', '.join(ops_added_list)}")
+                if ops_removed_list:
+                    parts.append(f"removed: {', '.join(ops_removed_list)}")
+                detail = f" ({'; '.join(parts)})" if parts else ""
+                lines.append(f"    ~ {name}: {b_count} operations -> {a_count} operations{detail}")
+            lines.append("")
+
+    if evidence_changes:
+        newly_obs = [e for e in evidence_changes if isinstance(e, dict) and e.get("type") == "field_became_observable"]
+        newly_unobs = [e for e in evidence_changes if isinstance(e, dict) and e.get("type") == "field_became_unobservable"]
+        if newly_obs:
+            lines.append("  Newly observable:")
+            for e in newly_obs:
+                ent = e.get("entityId")
+                path = e.get("path")
+                if isinstance(ent, str) and path == "/inputSchema":
+                    lines.append(f"    ? {ent}.inputSchema")
+                else:
+                    lines.append(f"    ? {json.dumps(e, ensure_ascii=False)}")
+            lines.append("")
+        if newly_unobs:
+            lines.append("  Newly unobservable:")
+            for e in newly_unobs:
+                ent = e.get("entityId")
+                path = e.get("path")
+                if isinstance(ent, str) and path == "/inputSchema":
+                    lines.append(f"    ? {ent}.inputSchema")
+                else:
+                    lines.append(f"    ? {json.dumps(e, ensure_ascii=False)}")
+            lines.append("")
 
     if len(lines) <= 5 or lines[-1] != "":
         # Ensure trailing newline and a clean end.
@@ -1986,7 +2553,10 @@ def diff_reports(before: dict, after: dict) -> str:
     # If nothing changed beyond header.
     has_change_sections = any(h in lines for h in ("  Tools:", "  Resources:", "  Prompts:", "  Capabilities (manifest-declared):"))
     if not has_change_sections:
-        lines.append("  No changes detected.\n")
+        if identity_comparable:
+            lines.append("  No changes detected.\n")
+        else:
+            lines.append("  No proven changes detected in comparable fields.\n")
 
     return "\n".join(lines).rstrip() + "\n"
 
@@ -2196,19 +2766,33 @@ def main() -> None:
         parser.add_argument("after", type=Path)
         ns = parser.parse_args(sys.argv[2:])
 
-        before = json.loads(ns.before.read_text(encoding="utf-8"))
-        after = json.loads(ns.after.read_text(encoding="utf-8"))
-        sys.stdout.write(diff_reports(before, after))
+        try:
+            before = json.loads(ns.before.read_text(encoding="utf-8"))
+            after = json.loads(ns.after.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            sys.stderr.write(f"mcp-preflight diff: error: invalid JSON ({e})\n")
+            raise SystemExit(2)
+
+        try:
+            sys.stdout.write(diff_reports(before, after))
+        except ValueError as e:
+            # User-facing failures (unsupported snapshot format/version, etc.) should not print a traceback.
+            sys.stderr.write(f"mcp-preflight diff: error: {e}\n")
+            raise SystemExit(2)
         return
 
     parser = argparse.ArgumentParser(
         prog="mcp-preflight",
         add_help=True,
-        description="Inspect an MCP server's exposed capabilities (tools/resources/prompts).",
-        epilog="Note: this runs the server process locally; it does not sandbox the server.",
+        description="Inspect, fingerprint, and diff an MCP server’s exposed capabilities.",
+        epilog=(
+            "Note: this starts the server process locally and does not sandbox it. "
+            "Preflight does not invoke declared tools."
+        ),
     )
-    parser.add_argument("--json", action="store_true", dest="as_json", help="Print machine-readable JSON")
-    parser.add_argument("--save", type=Path, help="Save JSON report to a file")
+    parser.add_argument("--version", action="version", version=f"mcp-preflight {__version__}")
+    parser.add_argument("--json", action="store_true", dest="as_json", help="Print the versioned snapshot as JSON")
+    parser.add_argument("--save", type=Path, help="Save the versioned snapshot to a file")
     parser.add_argument("--timeout", type=float, default=10.0, help="Timeout (seconds) for MCP calls (default: 10)")
     parser.add_argument("--no-signals", action="store_true", help="Disable heuristic signal scanning/output")
     parser.add_argument(
@@ -2304,6 +2888,15 @@ def main() -> None:
             pass
 
     _emit_report(report, save_path=ns.save, as_json=ns.as_json)
+    # For workflow/CI usage: emit a nonzero exit code for non-ok observations, while still
+    # producing a snapshot JSON on stdout/--save.
+    obs_status = None
+    if isinstance(report, dict):
+        obs = report.get("observation")
+        if isinstance(obs, dict):
+            obs_status = obs.get("status")
+    if str(obs_status or "") != "ok":
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/mcp_preflight.py
+++ b/mcp_preflight.py
@@ -831,8 +831,8 @@ def _canonicalize_surface(surface: dict) -> dict:
 
         Contract:
         - toolCapabilities entries are sorted by `tool`
-        - `operations` is treated as an unordered set for identity, represented as a sorted list
-          (duplicates are preserved; duplicate values should be flagged separately as malformed)
+        - `operations` order is not identity-bearing; values are sorted deterministically.
+          Duplicate values are preserved for detection and should cause the observation to be partial.
         """
         if not isinstance(tool_caps, list):
             return _canonicalize_schema(tool_caps)
@@ -1243,6 +1243,8 @@ async def inspect(
                                         )
                                         coverage["manifest"]["completed"] = False
                                         coverage["manifest"]["errorRule"] = "duplicate_operations"
+                                        # Do not claim manifest completeness when malformed.
+                                        # (Even though we parsed it, we refuse to produce a stable identity.)
 
                                     declaration_sources.append(
                                         {
@@ -1261,7 +1263,8 @@ async def inspect(
                                             "snippet": raw_hash,
                                         }
                                     )
-                                    coverage["manifest"]["completed"] = True
+                                    if not dupes:
+                                        coverage["manifest"]["completed"] = True
                                 else:
                                     status = _mark_partial(status)
                                     notes.append(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,11 @@ test = [
     "pytest>=8.0.0",
 ]
 
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/jordanstarrk/mcp-preflight"
 Repository = "https://github.com/jordanstarrk/mcp-preflight"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-preflight"
-version = "0.3.0"
+version = "0.4.0"
 description = "See what an MCP server exposes before you trust or connect it."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/baselines/toy-open.snapshot.json
+++ b/tests/baselines/toy-open.snapshot.json
@@ -1,0 +1,218 @@
+{
+  "observation": {
+    "capabilities": {
+      "prompts": true,
+      "resources": true,
+      "tools": true
+    },
+    "command": [
+      "python",
+      "tests/toy_servers/toy_open.py"
+    ],
+    "coverage": {
+      "manifest": {
+        "attempted": false,
+        "completed": true,
+        "declaredSupported": null
+      },
+      "prompts": {
+        "attempted": true,
+        "completed": true,
+        "declaredSupported": true,
+        "itemCount": 1
+      },
+      "resourceTemplates": {
+        "attempted": true,
+        "completed": true,
+        "declaredSupported": true,
+        "itemCount": 1
+      },
+      "resources": {
+        "attempted": true,
+        "completed": true,
+        "declaredSupported": true,
+        "itemCount": 1
+      },
+      "tools": {
+        "attempted": true,
+        "completed": true,
+        "declaredSupported": true,
+        "itemCount": 5
+      }
+    },
+    "errors": [],
+    "generatedAt": "2026-06-27T12:29:52.543541+00:00",
+    "localAnnotations": {
+      "risk": {
+        "destructive": 1,
+        "read": 2,
+        "write": 2
+      },
+      "signals": [],
+      "tools": [
+        {
+          "description": "Permanently delete an item",
+          "icon": "🔴",
+          "name": "delete_item",
+          "risk": "destructive"
+        },
+        {
+          "description": "Create a new item",
+          "icon": "🟡",
+          "name": "create_item",
+          "risk": "write"
+        },
+        {
+          "description": "An oddly-named tool with no obvious verb",
+          "icon": "🟡",
+          "name": "frobnicate",
+          "risk": "write"
+        },
+        {
+          "description": "Get a single item by ID",
+          "icon": "🟢",
+          "name": "get_item",
+          "risk": "read"
+        },
+        {
+          "description": "List all items in the database",
+          "icon": "🟢",
+          "name": "list_items",
+          "risk": "read"
+        }
+      ]
+    },
+    "notes": [],
+    "protocolVersion": "2025-11-25",
+    "serverName": "toy-open",
+    "status": "ok"
+  },
+  "snapshotFormatVersion": "1",
+  "surface": {
+    "declarationSources": [],
+    "prompts": [
+      {
+        "arguments": [
+          {
+            "name": "project_name",
+            "required": true
+          }
+        ],
+        "description": "Analyze items for a project",
+        "name": "analyze_items"
+      }
+    ],
+    "resourceTemplates": [
+      {
+        "annotations": null,
+        "description": "Single item by id",
+        "mimeType": "text/plain",
+        "name": "item_by_id",
+        "title": null,
+        "uriTemplate": "toy://items/{item_id}"
+      }
+    ],
+    "resources": [
+      {
+        "annotations": null,
+        "description": "All items",
+        "mimeType": "text/plain",
+        "name": "items",
+        "title": null,
+        "uri": "toy://items"
+      }
+    ],
+    "tools": [
+      {
+        "description": "Create a new item",
+        "inputSchema": {
+          "properties": {
+            "name": {
+              "title": "Name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "title": "create_itemArguments",
+          "type": "object"
+        },
+        "name": "create_item"
+      },
+      {
+        "description": "Permanently delete an item",
+        "inputSchema": {
+          "properties": {
+            "item_id": {
+              "title": "Item Id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "item_id"
+          ],
+          "title": "delete_itemArguments",
+          "type": "object"
+        },
+        "name": "delete_item"
+      },
+      {
+        "description": "An oddly-named tool with no obvious verb",
+        "inputSchema": {
+          "properties": {},
+          "title": "frobnicateArguments",
+          "type": "object"
+        },
+        "name": "frobnicate"
+      },
+      {
+        "description": "Get a single item by ID",
+        "inputSchema": {
+          "properties": {
+            "item_id": {
+              "title": "Item Id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "item_id"
+          ],
+          "title": "get_itemArguments",
+          "type": "object"
+        },
+        "name": "get_item"
+      },
+      {
+        "description": "List all items in the database",
+        "inputSchema": {
+          "properties": {},
+          "title": "list_itemsArguments",
+          "type": "object"
+        },
+        "name": "list_items"
+      }
+    ]
+  },
+  "surfaceCompleteness": "complete",
+  "surfaceDigest": "sha256:de40748c7be9ddd81ebedffde343e19d396bab7656c1b2bf5053ca9969a1f251",
+  "surfaceEntityDigests": {
+    "prompts": {
+      "analyze_items": "sha256:e7bc18a10969feeb605e3d215427cc1cfbdccae7ad9ff693f6f5af9e8b606e17"
+    },
+    "resourceTemplates": {
+      "toy://items/{item_id}": "sha256:fb30ac956f1234897304f3dd090a4e30bb77ed2b13bf14a34578b50549763eb5"
+    },
+    "resources": {
+      "toy://items": "sha256:fb36bb7226afaf6b5f1ede9ac16020e4322f61c41b2a40b379fdd04b1126276b"
+    },
+    "tools": {
+      "create_item": "sha256:21dd2d01104e713eb64d3b8c86b9e42bd18b91884b58857efae47e3a16741d30",
+      "delete_item": "sha256:61553f8b622f7c5abd203b40d19592e8d18644a3201ac670ca6a9bc1ec9afedf",
+      "frobnicate": "sha256:014a1176189cc90ef273dc5b59ace7ddc87cf8d37a5c451fbdf0dad2667fb8bb",
+      "get_item": "sha256:1fe597e73e448ef4c76b109797476a931cf34c84632211990835f0dd61b54882",
+      "list_items": "sha256:92b6ffb06f034f7890b847d9059799834b0a7970b76de8349fb165b0595b804b"
+    }
+  }
+}
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,5 +22,6 @@ def run_preflight_json(args: list[str], *, check: bool = True) -> subprocess.Com
 
 def parse_preflight_json(args: list[str]) -> dict:
     """Run mcp-preflight with --json, parse stdout, and return the snapshot dict."""
-    proc = run_preflight_json(args)
+    # Preflight may intentionally exit nonzero while still emitting a snapshot (e.g. partial surface).
+    proc = run_preflight_json(args, check=False)
     return json.loads(proc.stdout)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,6 @@ def run_preflight_json(args: list[str], *, check: bool = True) -> subprocess.Com
 
 
 def parse_preflight_json(args: list[str]) -> dict:
-    """Run mcp-preflight with --json, parse stdout, and return the report dict."""
+    """Run mcp-preflight with --json, parse stdout, and return the snapshot dict."""
     proc = run_preflight_json(args)
     return json.loads(proc.stdout)

--- a/tests/fixtures/conformance/canonical/basic_surface.json
+++ b/tests/fixtures/conformance/canonical/basic_surface.json
@@ -1,0 +1,123 @@
+{
+  "contractVersion": "1-experimental",
+  "surface": {
+    "tools": [
+      {
+        "name": "t",
+        "description": "d",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string" },
+            "action": { "enum": ["list", "get"] }
+          },
+          "required": ["id"]
+        }
+      }
+    ],
+    "resources": [
+      {
+        "uri": "toy://r",
+        "name": "R",
+        "title": null,
+        "description": "desc",
+        "mimeType": "text/plain",
+        "annotations": { "audience": ["user"] }
+      }
+    ],
+    "resourceTemplates": [
+      {
+        "uriTemplate": "toy://r/{id}",
+        "name": null,
+        "title": null,
+        "description": "tpl",
+        "mimeType": null,
+        "annotations": null
+      }
+    ],
+    "prompts": [
+      {
+        "name": "p",
+        "description": "pd",
+        "arguments": [
+          { "name": "b", "description": "bd", "required": false, "schema": { "type": "string" } },
+          { "name": "a", "description": "ad", "required": true, "schema": { "type": "string" } }
+        ]
+      }
+    ],
+    "declarationSources": [
+      {
+        "sourceType": "resource",
+        "name": "mcp_manifest",
+        "uri": "toy://mcp/manifest",
+        "extracted": {
+          "toolCapabilities": [
+            { "tool": "task", "description": "Task tool", "operations": ["list", "get", "create"] },
+            { "tool": "auth_login", "description": "Login" }
+          ]
+        }
+      }
+    ]
+  },
+  "expectedCanonical": {
+    "tools": [
+      {
+        "name": "t",
+        "description": "d",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "action": { "enum": ["get", "list"] },
+            "id": { "type": "string" }
+          },
+          "required": ["id"]
+        }
+      }
+    ],
+    "resources": [
+      {
+        "uri": "toy://r",
+        "name": "R",
+        "title": null,
+        "description": "desc",
+        "mimeType": "text/plain",
+        "annotations": { "audience": ["user"] }
+      }
+    ],
+    "resourceTemplates": [
+      {
+        "uriTemplate": "toy://r/{id}",
+        "name": null,
+        "title": null,
+        "description": "tpl",
+        "mimeType": null,
+        "annotations": null
+      }
+    ],
+    "prompts": [
+      {
+        "name": "p",
+        "description": "pd",
+        "arguments": [
+          { "name": "a", "description": "ad", "required": true, "schema": { "type": "string" } },
+          { "name": "b", "description": "bd", "required": false, "schema": { "type": "string" } }
+        ]
+      }
+    ],
+    "declarationSources": [
+      {
+        "sourceType": "resource",
+        "name": "mcp_manifest",
+        "uri": "toy://mcp/manifest",
+        "extracted": {
+          "toolCapabilities": [
+            { "tool": "auth_login", "description": "Login" },
+            { "tool": "task", "description": "Task tool", "operations": ["create", "get", "list"] }
+          ]
+        }
+      }
+    ]
+  },
+  "expectedDigest": "sha256:b30928339e89dede2776f5c9b3c3189147594342a70e87fae3950d2c2c62d4b6"
+}
+

--- a/tests/fixtures/conformance/changes/manifest_description_changed.json
+++ b/tests/fixtures/conformance/changes/manifest_description_changed.json
@@ -1,0 +1,50 @@
+{
+  "contractVersion": "1-experimental",
+  "before": {
+    "tools": [],
+    "resources": [],
+    "resourceTemplates": [],
+    "prompts": [],
+    "declarationSources": [
+      {
+        "sourceType": "resource",
+        "name": "mcp_manifest",
+        "uri": "toy://mcp/manifest",
+        "extracted": {
+          "toolCapabilities": [
+            { "tool": "task", "description": "A", "operations": ["get", "list"] }
+          ]
+        }
+      }
+    ]
+  },
+  "after": {
+    "tools": [],
+    "resources": [],
+    "resourceTemplates": [],
+    "prompts": [],
+    "declarationSources": [
+      {
+        "sourceType": "resource",
+        "name": "mcp_manifest",
+        "uri": "toy://mcp/manifest",
+        "extracted": {
+          "toolCapabilities": [
+            { "tool": "task", "description": "B", "operations": ["get", "list"] }
+          ]
+        }
+      }
+    ]
+  },
+  "expectedRecords": [
+    {
+      "type": "value_changed",
+      "entityType": "manifest_tool",
+      "entityId": "task",
+      "path": "/description",
+      "before": "A",
+      "after": "B"
+    }
+  ]
+}
+

--- a/tests/fixtures/conformance/changes/manifest_operation_added.json
+++ b/tests/fixtures/conformance/changes/manifest_operation_added.json
@@ -1,0 +1,49 @@
+{
+  "contractVersion": "1-experimental",
+  "before": {
+    "tools": [],
+    "resources": [],
+    "resourceTemplates": [],
+    "prompts": [],
+    "declarationSources": [
+      {
+        "sourceType": "resource",
+        "name": "mcp_manifest",
+        "uri": "toy://mcp/manifest",
+        "extracted": {
+          "toolCapabilities": [
+            { "tool": "task", "operations": ["get", "list"] }
+          ]
+        }
+      }
+    ]
+  },
+  "after": {
+    "tools": [],
+    "resources": [],
+    "resourceTemplates": [],
+    "prompts": [],
+    "declarationSources": [
+      {
+        "sourceType": "resource",
+        "name": "mcp_manifest",
+        "uri": "toy://mcp/manifest",
+        "extracted": {
+          "toolCapabilities": [
+            { "tool": "task", "operations": ["get", "list", "delete"] }
+          ]
+        }
+      }
+    ]
+  },
+  "expectedRecords": [
+    {
+      "type": "value_added",
+      "entityType": "manifest_tool",
+      "entityId": "task",
+      "path": "/operations",
+      "value": "delete"
+    }
+  ]
+}
+

--- a/tests/fixtures/conformance/changes/prompt_argument_required_changed.json
+++ b/tests/fixtures/conformance/changes/prompt_argument_required_changed.json
@@ -1,0 +1,44 @@
+{
+  "contractVersion": "1-experimental",
+  "before": {
+    "tools": [],
+    "resources": [],
+    "resourceTemplates": [],
+    "prompts": [
+      {
+        "name": "analyze",
+        "description": null,
+        "arguments": [
+          { "name": "project", "required": false }
+        ]
+      }
+    ],
+    "declarationSources": []
+  },
+  "after": {
+    "tools": [],
+    "resources": [],
+    "resourceTemplates": [],
+    "prompts": [
+      {
+        "name": "analyze",
+        "description": null,
+        "arguments": [
+          { "name": "project", "required": true }
+        ]
+      }
+    ],
+    "declarationSources": []
+  },
+  "expectedRecords": [
+    {
+      "type": "value_changed",
+      "entityType": "prompt",
+      "entityId": "analyze",
+      "path": "/arguments/project/required",
+      "before": false,
+      "after": true
+    }
+  ]
+}
+

--- a/tests/fixtures/conformance/changes/resource_description_changed.json
+++ b/tests/fixtures/conformance/changes/resource_description_changed.json
@@ -1,0 +1,32 @@
+{
+  "contractVersion": "1-experimental",
+  "before": {
+    "tools": [],
+    "resources": [
+      { "uri": "toy://r", "description": "desc" }
+    ],
+    "resourceTemplates": [],
+    "prompts": [],
+    "declarationSources": []
+  },
+  "after": {
+    "tools": [],
+    "resources": [
+      { "uri": "toy://r", "description": "desc2" }
+    ],
+    "resourceTemplates": [],
+    "prompts": [],
+    "declarationSources": []
+  },
+  "expectedRecords": [
+    {
+      "type": "value_changed",
+      "entityType": "resource",
+      "entityId": "toy://r",
+      "path": "/description",
+      "before": "desc",
+      "after": "desc2"
+    }
+  ]
+}
+

--- a/tests/fixtures/conformance/changes/tool_schema_enum_expanded.json
+++ b/tests/fixtures/conformance/changes/tool_schema_enum_expanded.json
@@ -1,0 +1,48 @@
+{
+  "contractVersion": "1-experimental",
+  "before": {
+    "tools": [
+      {
+        "name": "t",
+        "description": "d",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "action": { "enum": ["get", "list"] }
+          }
+        }
+      }
+    ],
+    "resources": [],
+    "resourceTemplates": [],
+    "prompts": [],
+    "declarationSources": []
+  },
+  "after": {
+    "tools": [
+      {
+        "name": "t",
+        "description": "d",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "action": { "enum": ["get", "list", "delete"] }
+          }
+        }
+      }
+    ],
+    "resources": [],
+    "resourceTemplates": [],
+    "prompts": [],
+    "declarationSources": []
+  },
+  "expectedRecords": [
+    {
+      "type": "value_changed",
+      "entityType": "tool",
+      "entityId": "t",
+      "path": "/inputSchema"
+    }
+  ]
+}
+

--- a/tests/fixtures/conformance/equivalence/reordered_manifest_ops_and_prompt_args.json
+++ b/tests/fixtures/conformance/equivalence/reordered_manifest_ops_and_prompt_args.json
@@ -1,0 +1,86 @@
+{
+  "contractVersion": "1-experimental",
+  "a": {
+    "tools": [
+      {
+        "name": "t",
+        "description": "d",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string" },
+            "action": { "enum": ["list", "get"] }
+          },
+          "required": ["id"]
+        }
+      }
+    ],
+    "resources": [],
+    "resourceTemplates": [],
+    "prompts": [
+      {
+        "name": "p",
+        "description": "pd",
+        "arguments": [
+          { "name": "b", "description": "bd", "required": false, "schema": { "type": "string" } },
+          { "name": "a", "description": "ad", "required": true, "schema": { "type": "string" } }
+        ]
+      }
+    ],
+    "declarationSources": [
+      {
+        "sourceType": "resource",
+        "name": "mcp_manifest",
+        "uri": "toy://mcp/manifest",
+        "extracted": {
+          "toolCapabilities": [
+            { "tool": "task", "description": "Task tool", "operations": ["list", "get", "create"] },
+            { "tool": "auth_login", "description": "Login" }
+          ]
+        }
+      }
+    ]
+  },
+  "b": {
+    "tools": [
+      {
+        "name": "t",
+        "description": "d",
+        "inputSchema": {
+          "required": ["id"],
+          "properties": {
+            "action": { "enum": ["get", "list"] },
+            "id": { "type": "string" }
+          },
+          "type": "object"
+        }
+      }
+    ],
+    "resources": [],
+    "resourceTemplates": [],
+    "prompts": [
+      {
+        "name": "p",
+        "description": "pd",
+        "arguments": [
+          { "name": "a", "description": "ad", "required": true, "schema": { "type": "string" } },
+          { "name": "b", "description": "bd", "required": false, "schema": { "type": "string" } }
+        ]
+      }
+    ],
+    "declarationSources": [
+      {
+        "sourceType": "resource",
+        "name": "mcp_manifest",
+        "uri": "toy://mcp/manifest",
+        "extracted": {
+          "toolCapabilities": [
+            { "tool": "auth_login", "description": "Login" },
+            { "tool": "task", "description": "Task tool", "operations": ["create", "list", "get"] }
+          ]
+        }
+      }
+    ]
+  }
+}
+

--- a/tests/show_outputs.py
+++ b/tests/show_outputs.py
@@ -51,7 +51,7 @@ SCENARIOS: list[tuple[str, str, list[str], dict[str, str]]] = [
     (
         "Partial resources (list_resources times out)",
         "toy_partial_resources.py",
-        ["--timeout", "0.8"],
+        ["--timeout", "1.2"],
         {},
     ),
     (

--- a/tests/test_canonicalization_contract.py
+++ b/tests/test_canonicalization_contract.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from mcp_preflight import _canonicalize_surface, _compute_surface_digest, _compute_surface_changes
+
+
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "conformance"
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _record_matches_subset(record: dict, expected: dict) -> bool:
+    for k, v in expected.items():
+        if k not in record:
+            return False
+        if record[k] != v:
+            return False
+    return True
+
+
+def test_conformance_canonical_basic_surface_golden() -> None:
+    fx = _load_json(FIXTURES_DIR / "canonical" / "basic_surface.json")
+    surface = fx["surface"]
+    expected_canonical = fx["expectedCanonical"]
+    expected_digest = fx["expectedDigest"]
+
+    canon = _canonicalize_surface(surface)
+    assert canon == expected_canonical
+    assert _compute_surface_digest(surface) == expected_digest
+
+
+def test_conformance_equivalence_reordered_manifest_ops_and_prompt_args() -> None:
+    fx = _load_json(FIXTURES_DIR / "equivalence" / "reordered_manifest_ops_and_prompt_args.json")
+    a = fx["a"]
+    b = fx["b"]
+
+    da = _compute_surface_digest(a)
+    db = _compute_surface_digest(b)
+    assert da == db
+
+    changes = _compute_surface_changes(a, b)
+    assert changes == []
+
+
+def test_conformance_changes_manifest_operation_added() -> None:
+    fx = _load_json(FIXTURES_DIR / "changes" / "manifest_operation_added.json")
+    before = fx["before"]
+    after = fx["after"]
+
+    assert _compute_surface_digest(before) != _compute_surface_digest(after)
+
+    changes = _compute_surface_changes(before, after)
+    assert changes
+
+    expected = fx["expectedRecords"]
+    for exp in expected:
+        assert any(_record_matches_subset(c, exp) for c in changes)
+
+
+def test_conformance_changes_resource_description_changed() -> None:
+    fx = _load_json(FIXTURES_DIR / "changes" / "resource_description_changed.json")
+    before = fx["before"]
+    after = fx["after"]
+
+    assert _compute_surface_digest(before) != _compute_surface_digest(after)
+
+    changes = _compute_surface_changes(before, after)
+    assert changes
+
+    expected = fx["expectedRecords"]
+    for exp in expected:
+        assert any(_record_matches_subset(c, exp) for c in changes)
+
+
+def test_conformance_changes_tool_schema_enum_expanded() -> None:
+    fx = _load_json(FIXTURES_DIR / "changes" / "tool_schema_enum_expanded.json")
+    before = fx["before"]
+    after = fx["after"]
+
+    assert _compute_surface_digest(before) != _compute_surface_digest(after)
+
+    changes = _compute_surface_changes(before, after)
+    assert changes
+
+    expected = fx["expectedRecords"]
+    for exp in expected:
+        assert any(_record_matches_subset(c, exp) for c in changes)
+
+
+def test_digest_diff_equivalence_invariant_for_complete_surfaces() -> None:
+    """
+    Release-blocking invariant for complete surfaces:
+
+    digest_equal == changes_empty
+    """
+    # Use representative pairs from fixtures (equivalence + changes).
+    equiv = _load_json(FIXTURES_DIR / "equivalence" / "reordered_manifest_ops_and_prompt_args.json")
+    pairs = [
+        (equiv["a"], equiv["b"]),
+    ]
+    for name in ("manifest_operation_added", "resource_description_changed", "tool_schema_enum_expanded"):
+        fx = _load_json(FIXTURES_DIR / "changes" / f"{name}.json")
+        pairs.append((fx["before"], fx["after"]))
+
+    for before, after in pairs:
+        digest_equal = _compute_surface_digest(before) == _compute_surface_digest(after)
+        changes_empty = _compute_surface_changes(before, after) == []
+        assert digest_equal == changes_empty
+
+
+def _iter_mutation_targets(obj: Any, prefix: str = ""):
+    if isinstance(obj, dict):
+        for k in sorted(obj.keys()):
+            p = f"{prefix}/{k}" if prefix else f"/{k}"
+            yield from _iter_mutation_targets(obj[k], p)
+        return
+    if isinstance(obj, list):
+        # Only treat lists-of-primitives as a mutatable leaf container.
+        # Lists that contain dicts/lists are traversed, but not mutated as a whole here,
+        # because canonicalization may drop nonconforming entries (e.g. declarationSources).
+        if all(not isinstance(x, (dict, list)) for x in obj):
+            yield (prefix or "/", obj)
+        for i, v in enumerate(obj):
+            p = f"{prefix}/{i}" if prefix else f"/{i}"
+            yield from _iter_mutation_targets(v, p)
+        return
+    # Primitive leaf (including None/bool/int/float/str)
+    yield (prefix or "/", obj)
+
+
+def _mutate_leaf(value: Any) -> Any:
+    if isinstance(value, str):
+        return value + "_mut"
+    if isinstance(value, bool):
+        return not value
+    if isinstance(value, int):
+        return value + 1
+    if isinstance(value, float):
+        return value + 1.0
+    if value is None:
+        return "mut"
+    if isinstance(value, list):
+        return list(value) + ["mut"]
+    # Fallback: coerce to string
+    return _mutate_leaf(str(value))
+
+
+def _set_at_path(root: Any, path: str, new_value: Any) -> Any:
+    parts = [p for p in path.split("/") if p]
+    if not parts:
+        return new_value
+    cur = root
+    for p in parts[:-1]:
+        if isinstance(cur, dict):
+            cur = cur[p]
+        else:
+            cur = cur[int(p)]
+    last = parts[-1]
+    if isinstance(cur, dict):
+        cur[last] = new_value
+    else:
+        cur[int(last)] = new_value
+    return root
+
+
+def test_mutation_coverage_invariant_identity_bearing_leaves() -> None:
+    """
+    Mutation-coverage invariant:
+
+    Any identity-bearing canonical leaf change must:
+    - change the surfaceDigest
+    - produce at least one change record
+    """
+    fx = _load_json(FIXTURES_DIR / "canonical" / "basic_surface.json")
+    base_surface = fx["surface"]
+    base_canon = _canonicalize_surface(base_surface)
+    base_digest = _compute_surface_digest(base_surface)
+
+    # Canonical surfaces should be JSON-safe; deep copy via round-trip.
+    for path, old in list(_iter_mutation_targets(base_canon)):
+        mutated = json.loads(json.dumps(base_canon, ensure_ascii=False))
+        new_val = _mutate_leaf(old)
+        _set_at_path(mutated, path, new_val)
+
+        mutated_digest = _compute_surface_digest(mutated)
+        assert mutated_digest != base_digest, f"digest did not change for mutation at {path}"
+
+        changes = _compute_surface_changes(base_canon, mutated)
+        assert changes, f"no change records for mutation at {path}"
+

--- a/tests/test_canonicalization_contract.py
+++ b/tests/test_canonicalization_contract.py
@@ -62,6 +62,21 @@ def test_conformance_changes_manifest_operation_added() -> None:
         assert any(_record_matches_subset(c, exp) for c in changes)
 
 
+def test_conformance_changes_manifest_description_changed() -> None:
+    fx = _load_json(FIXTURES_DIR / "changes" / "manifest_description_changed.json")
+    before = fx["before"]
+    after = fx["after"]
+
+    assert _compute_surface_digest(before) != _compute_surface_digest(after)
+
+    changes = _compute_surface_changes(before, after)
+    assert changes
+
+    expected = fx["expectedRecords"]
+    for exp in expected:
+        assert any(_record_matches_subset(c, exp) for c in changes)
+
+
 def test_conformance_changes_resource_description_changed() -> None:
     fx = _load_json(FIXTURES_DIR / "changes" / "resource_description_changed.json")
     before = fx["before"]
@@ -92,6 +107,21 @@ def test_conformance_changes_tool_schema_enum_expanded() -> None:
         assert any(_record_matches_subset(c, exp) for c in changes)
 
 
+def test_conformance_changes_prompt_argument_required_changed() -> None:
+    fx = _load_json(FIXTURES_DIR / "changes" / "prompt_argument_required_changed.json")
+    before = fx["before"]
+    after = fx["after"]
+
+    assert _compute_surface_digest(before) != _compute_surface_digest(after)
+
+    changes = _compute_surface_changes(before, after)
+    assert changes
+
+    expected = fx["expectedRecords"]
+    for exp in expected:
+        assert any(_record_matches_subset(c, exp) for c in changes)
+
+
 def test_digest_diff_equivalence_invariant_for_complete_surfaces() -> None:
     """
     Release-blocking invariant for complete surfaces:
@@ -103,7 +133,13 @@ def test_digest_diff_equivalence_invariant_for_complete_surfaces() -> None:
     pairs = [
         (equiv["a"], equiv["b"]),
     ]
-    for name in ("manifest_operation_added", "resource_description_changed", "tool_schema_enum_expanded"):
+    for name in (
+        "manifest_operation_added",
+        "manifest_description_changed",
+        "prompt_argument_required_changed",
+        "resource_description_changed",
+        "tool_schema_enum_expanded",
+    ):
         fx = _load_json(FIXTURES_DIR / "changes" / f"{name}.json")
         pairs.append((fx["before"], fx["after"]))
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -336,3 +336,20 @@ def test_toy_open_has_no_manifest_key() -> None:
     """Servers without a ://mcp/manifest resource should not have the key."""
     snap = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_open.py")])
     assert snap["surface"]["declarationSources"] == []
+
+
+def test_toy_manifest_duplicate_operations_marks_partial_and_omits_digest() -> None:
+    """Malformed manifests should produce partial snapshots without a surfaceDigest."""
+    snap = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_manifest_dupe_ops.py")])
+    assert snap["observation"]["serverName"] == "toy-manifest-dupe-ops"
+    assert snap["surfaceCompleteness"] == "partial"
+    assert "surfaceDigest" not in snap
+
+    manifest_cov = snap["observation"]["coverage"]["manifest"]
+    assert manifest_cov["completed"] is False
+    assert manifest_cov["errorRule"] == "duplicate_operations"
+
+    assert any(
+        (n.get("kind") == "declaration_source" and n.get("name") == "mcp_manifest" and n.get("rule") == "duplicate_operations")
+        for n in (snap["observation"].get("notes") or [])
+    )

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -180,10 +180,10 @@ def test_print_tool_capabilities_shows_operations(capsys) -> None:
     ]
     print_tool_capabilities(tool_caps)
     out = capsys.readouterr().out
-    assert "Action-level Capabilities (server-declared" in out
+    assert "Additional declared operations (from server manifest" in out
     assert "4 operations across 2 tools" in out
-    assert "Not directly visible via MCP introspection" in out
-    assert "additional actions exposed behind the tools above" in out
+    assert "Not represented as separate entries in tools/list" in out
+    assert "server-declared actions multiplexed behind the tools above" in out
     assert "invoice (3): list, get, create" in out
     assert "auth_login (single action)" in out
 
@@ -226,7 +226,7 @@ def test_print_tool_capabilities_at_scale(capsys) -> None:
     out = capsys.readouterr().out
     # 6 + 5 + 5 + 3 dispatched + 3 single-purpose = 22
     assert "22 operations across 7 tools" in out
-    assert "Not directly visible via MCP introspection" in out
+    assert "Not represented as separate entries in tools/list" in out
     assert "task (6)" in out
     assert "↳ search" in out
 
@@ -235,24 +235,24 @@ def test_print_tool_capabilities_at_scale(capsys) -> None:
 
 
 def test_toy_capabilities_json_has_manifest_key() -> None:
-    report = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_capabilities.py")])
-    assert report["server"]["name"] == "toy-capabilities"
-    assert report["status"] == "ok"
-
-    tc = report.get("manifest")
-    assert tc is not None
-    assert isinstance(tc, list)
+    snap = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_capabilities.py")])
+    assert snap["observation"]["serverName"] == "toy-capabilities"
+    assert snap["observation"]["status"] == "ok"
+    sources = snap["surface"]["declarationSources"]
+    assert any(s.get("name") == "mcp_manifest" for s in sources)
 
 
 def test_toy_capabilities_has_29_tools_in_manifest() -> None:
-    report = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_capabilities.py")])
-    tc = report["manifest"]
+    snap = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_capabilities.py")])
+    src = next(s for s in snap["surface"]["declarationSources"] if s.get("name") == "mcp_manifest")
+    tc = src["extracted"]["toolCapabilities"]
     assert len(tc) == 29
 
 
 def test_toy_capabilities_dispatch_tools_have_operations() -> None:
-    report = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_capabilities.py")])
-    tc = report["manifest"]
+    snap = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_capabilities.py")])
+    src = next(s for s in snap["surface"]["declarationSources"] if s.get("name") == "mcp_manifest")
+    tc = src["extracted"]["toolCapabilities"]
 
     by_name = {e["tool"]: e for e in tc}
 
@@ -275,8 +275,9 @@ def test_toy_capabilities_dispatch_tools_have_operations() -> None:
 
 def test_toy_capabilities_report_dispatch_tools_expand() -> None:
     """Tools using 'report' as dispatch_key should also expand."""
-    report = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_capabilities.py")])
-    by_name = {e["tool"]: e for e in report["manifest"]}
+    snap = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_capabilities.py")])
+    src = next(s for s in snap["surface"]["declarationSources"] if s.get("name") == "mcp_manifest")
+    by_name = {e["tool"]: e for e in src["extracted"]["toolCapabilities"]}
 
     assert "operations" in by_name["analytics"]
     assert len(by_name["analytics"]["operations"]) == 10
@@ -287,8 +288,9 @@ def test_toy_capabilities_report_dispatch_tools_expand() -> None:
 
 
 def test_toy_capabilities_single_purpose_tools_have_no_operations() -> None:
-    report = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_capabilities.py")])
-    by_name = {e["tool"]: e for e in report["manifest"]}
+    snap = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_capabilities.py")])
+    src = next(s for s in snap["surface"]["declarationSources"] if s.get("name") == "mcp_manifest")
+    by_name = {e["tool"]: e for e in src["extracted"]["toolCapabilities"]}
 
     for name in ("auth_login", "auth_complete", "auth_status", "auth_logout", "search"):
         assert "operations" not in by_name[name], f"{name} should not have operations"
@@ -296,8 +298,9 @@ def test_toy_capabilities_single_purpose_tools_have_no_operations() -> None:
 
 def test_toy_capabilities_total_operation_count() -> None:
     """The manifest should reflect 150+ dispatched operations."""
-    report = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_capabilities.py")])
-    tc = report["manifest"]
+    snap = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_capabilities.py")])
+    src = next(s for s in snap["surface"]["declarationSources"] if s.get("name") == "mcp_manifest")
+    tc = src["extracted"]["toolCapabilities"]
 
     total_dispatched = sum(len(e["operations"]) for e in tc if "operations" in e)
     assert total_dispatched >= 150
@@ -313,7 +316,7 @@ def test_toy_capabilities_text_output_shows_scale() -> None:
         text=True,
         check=True,
     )
-    assert "Action-level Capabilities (server-declared" in proc.stdout
+    assert "Additional declared operations (from server manifest" in proc.stdout
     # Should show "156 operations across 29 tools" (151 dispatched + 5 single)
     assert "29 tools" in proc.stdout
     assert "156 operations" in proc.stdout
@@ -325,11 +328,11 @@ def test_toy_capabilities_text_output_shows_scale() -> None:
 
 def test_toy_capabilities_list_tools_returns_29_tools() -> None:
     """The MCP server itself should register all 29 tools."""
-    report = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_capabilities.py")])
-    assert len(report["tools"]) == 29
+    snap = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_capabilities.py")])
+    assert len(snap["surface"]["tools"]) == 29
 
 
 def test_toy_open_has_no_manifest_key() -> None:
     """Servers without a ://mcp/manifest resource should not have the key."""
-    report = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_open.py")])
-    assert "manifest" not in report
+    snap = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_open.py")])
+    assert snap["surface"]["declarationSources"] == []

--- a/tests/test_cli_behavior.py
+++ b/tests/test_cli_behavior.py
@@ -121,3 +121,71 @@ def test_cli_diff_subcommand_prints_diff() -> None:
         assert "Diff" in proc.stdout
         assert "+ t" in proc.stdout
 
+
+def test_cli_version_flag_prints_version() -> None:
+    proc = subprocess.run(
+        [sys.executable, "-m", "mcp_preflight", "--version"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    assert proc.stdout.strip().startswith("mcp-preflight ")
+
+
+def test_cli_diff_rejects_unsupported_snapshot_version_without_traceback() -> None:
+    before = {
+        "snapshotFormatVersion": "999",
+        "surfaceCompleteness": "complete",
+        "surface": {"tools": [], "resources": [], "resourceTemplates": [], "prompts": [], "declarationSources": []},
+        "surfaceDigest": "sha256:" + "0" * 64,
+        "surfaceEntityDigests": {"tools": {}, "prompts": {}, "resources": {}, "resourceTemplates": {}},
+        "observation": {
+            "generatedAt": "2026-01-01T00:00:00Z",
+            "protocolVersion": "x",
+            "serverName": "s",
+            "command": [],
+            "status": "ok",
+            "capabilities": {"tools": True, "resources": False, "prompts": False},
+            "coverage": {},
+            "notes": [],
+            "errors": [],
+            "localAnnotations": {"tools": [], "risk": {}, "signals": []},
+        },
+    }
+    after = {
+        "snapshotFormatVersion": "1",
+        "surfaceCompleteness": "complete",
+        "surface": {"tools": [], "resources": [], "resourceTemplates": [], "prompts": [], "declarationSources": []},
+        "surfaceDigest": "sha256:" + "0" * 64,
+        "surfaceEntityDigests": {"tools": {}, "prompts": {}, "resources": {}, "resourceTemplates": {}},
+        "observation": {
+            "generatedAt": "2026-01-01T00:00:00Z",
+            "protocolVersion": "x",
+            "serverName": "s",
+            "command": [],
+            "status": "ok",
+            "capabilities": {"tools": True, "resources": False, "prompts": False},
+            "coverage": {},
+            "notes": [],
+            "errors": [],
+            "localAnnotations": {"tools": [], "risk": {}, "signals": []},
+        },
+    }
+    with tempfile.TemporaryDirectory() as td:
+        b = Path(td) / "before.json"
+        a = Path(td) / "after.json"
+        b.write_text(json.dumps(before), encoding="utf-8")
+        a.write_text(json.dumps(after), encoding="utf-8")
+
+        proc = subprocess.run(
+            [sys.executable, "-m", "mcp_preflight", "diff", str(b), str(a)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert proc.returncode != 0
+        combined = proc.stdout + proc.stderr
+        assert "Unsupported snapshotFormatVersion: 999" in combined
+        assert "Traceback" not in combined
+

--- a/tests/test_cli_behavior.py
+++ b/tests/test_cli_behavior.py
@@ -30,8 +30,8 @@ def test_cli_save_writes_json_report() -> None:
         )
         assert proc.stdout.strip()
         assert out.exists()
-        report = json.loads(out.read_text(encoding="utf-8"))
-        assert report["server"]["name"] == "toy-open"
+        snap = json.loads(out.read_text(encoding="utf-8"))
+        assert snap["observation"]["serverName"] == "toy-open"
 
 
 def test_cli_no_signals_disables_signal_output_in_json() -> None:
@@ -50,8 +50,8 @@ def test_cli_no_signals_disables_signal_output_in_json() -> None:
         text=True,
         check=True,
     )
-    report = json.loads(proc.stdout)
-    assert report["signals"] == []
+    snap = json.loads(proc.stdout)
+    assert snap["observation"]["localAnnotations"]["signals"] == []
 
 
 def test_cli_env_requires_key_value() -> None:
@@ -66,8 +66,44 @@ def test_cli_env_requires_key_value() -> None:
 
 
 def test_cli_diff_subcommand_prints_diff() -> None:
-    before = {"server": {"name": "s"}, "risk": {"write": 0, "destructive": 0, "read": 0}, "tools": [], "resources": [], "resourceTemplates": [], "prompts": []}
-    after = {"server": {"name": "s"}, "risk": {"write": 1, "destructive": 0, "read": 0}, "tools": [{"name": "t", "risk": "write"}], "resources": [], "resourceTemplates": [], "prompts": []}
+    before = {
+        "snapshotFormatVersion": "1",
+        "surfaceCompleteness": "complete",
+        "surface": {"tools": [], "resources": [], "resourceTemplates": [], "prompts": [], "declarationSources": []},
+        "surfaceDigest": "sha256:" + "0" * 64,
+        "surfaceEntityDigests": {"tools": {}, "prompts": {}, "resources": {}, "resourceTemplates": {}},
+        "observation": {
+            "generatedAt": "2026-01-01T00:00:00Z",
+            "protocolVersion": "x",
+            "serverName": "s",
+            "command": [],
+            "status": "ok",
+            "capabilities": {"tools": True, "resources": False, "prompts": False},
+            "coverage": {},
+            "notes": [],
+            "errors": [],
+            "localAnnotations": {"tools": [], "risk": {}, "signals": []},
+        },
+    }
+    after = {
+        "snapshotFormatVersion": "1",
+        "surfaceCompleteness": "complete",
+        "surface": {"tools": [{"name": "t", "description": "", "inputSchema": {"type": "object"}}], "resources": [], "resourceTemplates": [], "prompts": [], "declarationSources": []},
+        "surfaceDigest": "sha256:" + "1" * 64,
+        "surfaceEntityDigests": {"tools": {"t": "sha256:" + "2" * 64}, "prompts": {}, "resources": {}, "resourceTemplates": {}},
+        "observation": {
+            "generatedAt": "2026-01-01T00:00:00Z",
+            "protocolVersion": "x",
+            "serverName": "s",
+            "command": [],
+            "status": "ok",
+            "capabilities": {"tools": True, "resources": False, "prompts": False},
+            "coverage": {},
+            "notes": [],
+            "errors": [],
+            "localAnnotations": {"tools": [], "risk": {}, "signals": []},
+        },
+    }
 
     with tempfile.TemporaryDirectory() as td:
         b = Path(td) / "before.json"
@@ -83,5 +119,5 @@ def test_cli_diff_subcommand_prints_diff() -> None:
             check=True,
         )
         assert "Diff" in proc.stdout
-        assert "+ t (write)" in proc.stdout
+        assert "+ t" in proc.stdout
 

--- a/tests/test_cli_behavior.py
+++ b/tests/test_cli_behavior.py
@@ -283,3 +283,16 @@ def test_cli_check_rejects_invalid_baseline() -> None:
         assert proc.returncode == 4
         assert "Unsupported snapshotFormatVersion: 999" in (proc.stdout + proc.stderr)
 
+
+def test_cli_check_missing_baseline_fails_cleanly() -> None:
+    proc = subprocess.run(
+        [sys.executable, "-m", "mcp_preflight", "check", "does-not-exist.json", sys.executable, str(TOY_DIR / "toy_open.py")],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert proc.returncode == 4
+    combined = proc.stdout + proc.stderr
+    assert "could not read baseline" in combined
+    assert "Traceback" not in combined
+

--- a/tests/test_cli_behavior.py
+++ b/tests/test_cli_behavior.py
@@ -189,3 +189,97 @@ def test_cli_diff_rejects_unsupported_snapshot_version_without_traceback() -> No
         assert "Unsupported snapshotFormatVersion: 999" in combined
         assert "Traceback" not in combined
 
+
+def test_cli_check_exit_codes_and_json_output() -> None:
+    # Build a baseline snapshot by inspecting toy_open.
+    proc = subprocess.run(
+        [sys.executable, "-m", "mcp_preflight", "--json", sys.executable, str(TOY_DIR / "toy_open.py")],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    baseline_snap = json.loads(proc.stdout)
+    assert baseline_snap.get("surfaceDigest")
+
+    with tempfile.TemporaryDirectory() as td:
+        baseline = Path(td) / "baseline.json"
+        baseline.write_text(json.dumps(baseline_snap), encoding="utf-8")
+
+        # Unchanged: check against same server.
+        proc2 = subprocess.run(
+            [sys.executable, "-m", "mcp_preflight", "check", str(baseline), sys.executable, str(TOY_DIR / "toy_open.py")],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert proc2.returncode == 0
+        assert "No changes detected." in proc2.stdout
+
+        # Changed: check against a different server surface.
+        proc3 = subprocess.run(
+            [sys.executable, "-m", "mcp_preflight", "check", str(baseline), sys.executable, str(TOY_DIR / "toy_tools_only.py")],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert proc3.returncode == 1
+        assert "Tools:" in proc3.stdout
+
+        # Machine-readable output.
+        proc4 = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "mcp_preflight",
+                "check",
+                "--json",
+                str(baseline),
+                sys.executable,
+                str(TOY_DIR / "toy_open.py"),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert proc4.returncode == 0
+        result = json.loads(proc4.stdout)
+        assert result["identityComparable"] is True
+        assert result["changed"] is False
+        assert result["exitCode"] == 0
+        assert isinstance(result.get("changes"), list)
+
+        # Partial/incomparable: should be 3, never 1.
+        proc5 = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "mcp_preflight",
+                "check",
+                "--timeout",
+                "1.0",
+                str(baseline),
+                sys.executable,
+                str(TOY_DIR / "toy_partial_resources.py"),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert proc5.returncode == 3
+
+
+def test_cli_check_rejects_invalid_baseline() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        baseline = Path(td) / "baseline.json"
+        baseline.write_text(json.dumps({"snapshotFormatVersion": "999"}), encoding="utf-8")
+
+        proc = subprocess.run(
+            [sys.executable, "-m", "mcp_preflight", "check", str(baseline), sys.executable, str(TOY_DIR / "toy_open.py")],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert proc.returncode == 4
+        assert "Unsupported snapshotFormatVersion: 999" in (proc.stdout + proc.stderr)
+

--- a/tests/test_diff_reports.py
+++ b/tests/test_diff_reports.py
@@ -3,29 +3,84 @@ from __future__ import annotations
 from mcp_preflight import diff_reports
 
 
-def test_diff_reports_detects_added_removed_and_risk_changes() -> None:
-    before = {
-        "server": {"name": "s"},
-        "risk": {"write": 1, "destructive": 0, "read": 0},
-        "tools": [{"name": "t1", "risk": "write"}, {"name": "t2", "risk": "read"}],
-        "resources": ["toy://a"],
-        "resourceTemplates": ["toy://t/{id}"],
-        "prompts": [{"name": "p1"}],
-    }
-    after = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 1, "read": 0},
-        "tools": [{"name": "t1", "risk": "destructive"}, {"name": "t3", "risk": "read"}],
-        "resources": ["toy://b"],
-        "resourceTemplates": ["toy://t/{id}", "toy://u/{id}"],
-        "prompts": [{"name": "p2"}],
+def _snapshot(
+    *,
+    server_name: str = "s",
+    tools: list[dict] | None = None,
+    resources: list[str] | None = None,
+    templates: list[str] | None = None,
+    prompts: list[dict] | None = None,
+    manifest_caps: list[dict] | None = None,
+    surface_digest: str = "sha256:" + "0" * 64,
+) -> dict:
+    decl_sources: list[dict] = []
+    if manifest_caps is not None:
+        decl_sources.append(
+            {
+                "sourceType": "resource",
+                "name": "mcp_manifest",
+                "uri": f"{server_name}://mcp/manifest",
+                "status": "parsed",
+                "rawHash": "sha256:" + "f" * 64,
+                "extracted": {"toolCapabilities": manifest_caps},
+            }
+        )
+    return {
+        "snapshotFormatVersion": "1",
+        "surfaceCompleteness": "complete",
+        "surfaceDigest": surface_digest,
+        "surfaceEntityDigests": {"tools": {}, "prompts": {}, "resources": {}, "resourceTemplates": {}},
+        "observation": {
+            "generatedAt": "2026-01-01T00:00:00Z",
+            "protocolVersion": "x",
+            "serverName": server_name,
+            "command": [],
+            "status": "ok",
+            "capabilities": {"tools": True, "resources": True, "prompts": True},
+            "coverage": {},
+            "notes": [],
+            "errors": [],
+            "localAnnotations": {"tools": [], "risk": {}, "signals": []},
+        },
+        "surface": {
+            "tools": tools or [],
+            "resources": [{"uri": u} for u in (resources or [])],
+            "resourceTemplates": [{"uriTemplate": u} for u in (templates or [])],
+            "prompts": prompts or [],
+            "declarationSources": decl_sources,
+        },
     }
 
+
+def test_diff_reports_detects_added_removed_and_metadata_changes() -> None:
+    before = _snapshot(
+        tools=[
+            {"name": "t1", "description": "one", "inputSchema": {"type": "object", "properties": {"a": {"type": "string"}}}},
+            {"name": "t2", "description": "two", "inputSchema": {"type": "object"}},
+        ],
+        resources=["toy://a"],
+        templates=["toy://t/{id}"],
+        prompts=[{"name": "p1", "description": None, "arguments": []}],
+        surface_digest="sha256:" + "a" * 64,
+    )
+    after = _snapshot(
+        tools=[
+            {"name": "t1", "description": "ONE", "inputSchema": {"type": "object", "properties": {"a": {"type": "string"}, "b": {"enum": ["x", "y"]}}}},
+            {"name": "t3", "description": "three", "inputSchema": {"type": "object"}},
+        ],
+        resources=["toy://b"],
+        templates=["toy://t/{id}", "toy://u/{id}"],
+        prompts=[{"name": "p2", "description": None, "arguments": []}],
+        surface_digest="sha256:" + "b" * 64,
+    )
+
     diff = diff_reports(before, after)
+    assert "surfaceDigest" in diff
     assert "Tools:" in diff
     assert "+ t3" in diff
     assert "- t2" in diff
-    assert "~ t1: write -> destructive" in diff
+    assert "~ t1.description" in diff or "~ t1.description:" in diff
+    assert "~ t1.inputSchema" in diff
     assert "Resources:" in diff
     assert "+ toy://b" in diff
     assert "- toy://a" in diff
@@ -39,109 +94,57 @@ def test_diff_reports_detects_added_removed_and_risk_changes() -> None:
 
 
 def test_diff_detects_added_manifest_tool() -> None:
-    before = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 0, "read": 0},
-        "tools": [], "resources": [], "resourceTemplates": [], "prompts": [],
-        "manifest": [
-            {"tool": "task", "operations": ["list", "get"]},
-        ],
-    }
-    after = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 0, "read": 0},
-        "tools": [], "resources": [], "resourceTemplates": [], "prompts": [],
-        "manifest": [
+    before = _snapshot(manifest_caps=[{"tool": "task", "operations": ["list", "get"]}])
+    after = _snapshot(
+        manifest_caps=[
             {"tool": "task", "operations": ["list", "get"]},
             {"tool": "budget", "operations": ["overview", "alerts", "burn_down"]},
-        ],
-    }
+        ]
+    )
     diff = diff_reports(before, after)
-    assert "Capabilities:" in diff
+    assert "Capabilities (manifest-declared):" in diff
     assert "+ budget (3 operations)" in diff
 
 
 def test_diff_detects_removed_manifest_tool() -> None:
-    before = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 0, "read": 0},
-        "tools": [], "resources": [], "resourceTemplates": [], "prompts": [],
-        "manifest": [
+    before = _snapshot(
+        manifest_caps=[
             {"tool": "task", "operations": ["list", "get"]},
             {"tool": "legacy", "operations": ["run"]},
-        ],
-    }
-    after = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 0, "read": 0},
-        "tools": [], "resources": [], "resourceTemplates": [], "prompts": [],
-        "manifest": [
-            {"tool": "task", "operations": ["list", "get"]},
-        ],
-    }
+        ]
+    )
+    after = _snapshot(manifest_caps=[{"tool": "task", "operations": ["list", "get"]}])
     diff = diff_reports(before, after)
-    assert "Capabilities:" in diff
+    assert "Capabilities (manifest-declared):" in diff
     assert "- legacy (1 operations)" in diff
 
 
 def test_diff_detects_changed_operations() -> None:
-    before = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 0, "read": 0},
-        "tools": [], "resources": [], "resourceTemplates": [], "prompts": [],
-        "manifest": [
-            {"tool": "invoice", "operations": ["list", "get", "create", "update", "stats"]},
-        ],
-    }
-    after = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 0, "read": 0},
-        "tools": [], "resources": [], "resourceTemplates": [], "prompts": [],
-        "manifest": [
-            {"tool": "invoice", "operations": ["list", "get", "create", "update", "stats", "issue", "send", "mark_paid"]},
-        ],
-    }
+    before = _snapshot(manifest_caps=[{"tool": "invoice", "operations": ["list", "get", "create", "update", "stats"]}])
+    after = _snapshot(
+        manifest_caps=[
+            {"tool": "invoice", "operations": ["list", "get", "create", "update", "stats", "issue", "send", "mark_paid"]}
+        ]
+    )
     diff = diff_reports(before, after)
-    assert "Capabilities:" in diff
+    assert "Capabilities (manifest-declared):" in diff
     assert "~ invoice: 5 operations -> 8 operations" in diff
     assert "added: issue, mark_paid, send" in diff
 
 
 def test_diff_detects_removed_operations() -> None:
-    before = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 0, "read": 0},
-        "tools": [], "resources": [], "resourceTemplates": [], "prompts": [],
-        "manifest": [
-            {"tool": "task", "operations": ["list", "get", "create", "delete"]},
-        ],
-    }
-    after = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 0, "read": 0},
-        "tools": [], "resources": [], "resourceTemplates": [], "prompts": [],
-        "manifest": [
-            {"tool": "task", "operations": ["list", "get", "create"]},
-        ],
-    }
+    before = _snapshot(manifest_caps=[{"tool": "task", "operations": ["list", "get", "create", "delete"]}])
+    after = _snapshot(manifest_caps=[{"tool": "task", "operations": ["list", "get", "create"]}])
     diff = diff_reports(before, after)
     assert "~ task: 4 operations -> 3 operations" in diff
     assert "removed: delete" in diff
 
 
 def test_diff_no_manifest_in_either_report_shows_no_capabilities_section() -> None:
-    before = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 0, "read": 0},
-        "tools": [], "resources": [], "resourceTemplates": [], "prompts": [],
-    }
-    after = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 0, "read": 0},
-        "tools": [], "resources": [], "resourceTemplates": [], "prompts": [],
-    }
+    before = _snapshot()
+    after = _snapshot()
     diff = diff_reports(before, after)
-    assert "Capabilities:" not in diff
+    assert "Capabilities (manifest-declared):" not in diff
     assert "No changes detected." in diff
 
 
@@ -150,100 +153,8 @@ def test_diff_unchanged_manifest_shows_no_capabilities_section() -> None:
         {"tool": "task", "operations": ["list", "get"]},
         {"tool": "auth_login"},
     ]
-    before = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 0, "read": 0},
-        "tools": [], "resources": [], "resourceTemplates": [], "prompts": [],
-        "manifest": manifest,
-    }
-    after = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 0, "read": 0},
-        "tools": [], "resources": [], "resourceTemplates": [], "prompts": [],
-        "manifest": manifest,
-    }
+    before = _snapshot(manifest_caps=manifest)
+    after = _snapshot(manifest_caps=manifest)
     diff = diff_reports(before, after)
-    assert "Capabilities:" not in diff
-
-
-def test_diff_single_action_tool_added() -> None:
-    before = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 0, "read": 0},
-        "tools": [], "resources": [], "resourceTemplates": [], "prompts": [],
-        "manifest": [],
-    }
-    after = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 0, "read": 0},
-        "tools": [], "resources": [], "resourceTemplates": [], "prompts": [],
-        "manifest": [{"tool": "auth_login"}],
-    }
-    diff = diff_reports(before, after)
-    assert "Capabilities (now visible):" in diff
-    assert "+ auth_login" in diff
-    # Single action tool should not show operation count in its own line
-    assert "+ auth_login (" not in diff
-
-
-def test_diff_before_has_no_manifest_after_does() -> None:
-    """Server adds a manifest between scans — all tools show as added."""
-    before = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 0, "read": 0},
-        "tools": [], "resources": [], "resourceTemplates": [], "prompts": [],
-    }
-    after = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 0, "read": 0},
-        "tools": [], "resources": [], "resourceTemplates": [], "prompts": [],
-        "manifest": [
-            {"tool": "task", "operations": ["list", "get", "create"]},
-            {"tool": "auth_login"},
-        ],
-    }
-    diff = diff_reports(before, after)
-    assert "Capabilities (now visible):" in diff
-    assert "+ task (3 operations)" in diff
-    assert "+ auth_login" in diff
-
-
-def test_diff_before_has_manifest_after_does_not() -> None:
-    """Server removes its manifest — all tools show as removed."""
-    before = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 0, "read": 0},
-        "tools": [], "resources": [], "resourceTemplates": [], "prompts": [],
-        "manifest": [
-            {"tool": "invoice", "operations": ["list", "get"]},
-        ],
-    }
-    after = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 0, "read": 0},
-        "tools": [], "resources": [], "resourceTemplates": [], "prompts": [],
-    }
-    diff = diff_reports(before, after)
-    assert "Capabilities:" in diff
-    assert "- invoice (2 operations)" in diff
-
-
-def test_diff_tool_changes_from_dispatched_to_single_action() -> None:
-    """Tool drops its operations — effectively goes from dispatched to single."""
-    before = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 0, "read": 0},
-        "tools": [], "resources": [], "resourceTemplates": [], "prompts": [],
-        "manifest": [{"tool": "task", "operations": ["list", "get"]}],
-    }
-    after = {
-        "server": {"name": "s"},
-        "risk": {"write": 0, "destructive": 0, "read": 0},
-        "tools": [], "resources": [], "resourceTemplates": [], "prompts": [],
-        "manifest": [{"tool": "task"}],
-    }
-    diff = diff_reports(before, after)
-    assert "Capabilities:" in diff
-    assert "~ task: 2 operations -> 0 operations" in diff
-    assert "removed: get, list" in diff
+    assert "Capabilities (manifest-declared):" not in diff
 

--- a/tests/test_diff_reports.py
+++ b/tests/test_diff_reports.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from mcp_preflight import diff_reports
 
 
@@ -7,8 +10,8 @@ def _snapshot(
     *,
     server_name: str = "s",
     tools: list[dict] | None = None,
-    resources: list[str] | None = None,
-    templates: list[str] | None = None,
+    resources: list[object] | None = None,
+    templates: list[object] | None = None,
     prompts: list[dict] | None = None,
     manifest_caps: list[dict] | None = None,
     surface_digest: str = "sha256:" + "0" * 64,
@@ -44,10 +47,40 @@ def _snapshot(
         },
         "surface": {
             "tools": tools or [],
-            "resources": [{"uri": u} for u in (resources or [])],
-            "resourceTemplates": [{"uriTemplate": u} for u in (templates or [])],
+            "resources": [
+                (r if isinstance(r, dict) else {"uri": r})
+                for r in (resources or [])
+            ],
+            "resourceTemplates": [
+                (t if isinstance(t, dict) else {"uriTemplate": t})
+                for t in (templates or [])
+            ],
             "prompts": prompts or [],
             "declarationSources": decl_sources,
+        },
+    }
+
+
+def _wrap_surface_as_snapshot(surface: dict, *, server_name: str = "s") -> dict:
+    """Build a minimal complete snapshot object for diff_reports() tests."""
+    return {
+        "snapshotFormatVersion": "1",
+        "surfaceCompleteness": "complete",
+        "surface": surface,
+        # Placeholder surfaceDigest; tests that care about equality/inequality should supply real values.
+        "surfaceDigest": "sha256:" + "0" * 64,
+        "surfaceEntityDigests": {"tools": {}, "prompts": {}, "resources": {}, "resourceTemplates": {}},
+        "observation": {
+            "generatedAt": "x",
+            "protocolVersion": "x",
+            "serverName": server_name,
+            "command": [],
+            "status": "ok",
+            "capabilities": {"tools": True, "resources": True, "prompts": True},
+            "coverage": {},
+            "notes": [],
+            "errors": [],
+            "localAnnotations": {"tools": [], "risk": {}, "signals": []},
         },
     }
 
@@ -88,6 +121,70 @@ def test_diff_reports_detects_added_removed_and_metadata_changes() -> None:
     assert "Prompts:" in diff
     assert "+ p2" in diff
     assert "- p1" in diff
+
+
+def test_diff_reports_shows_resource_metadata_changes_as_tilde_lines() -> None:
+    before = _snapshot(
+        resources=[{"uri": "toy://r", "description": "desc"}],
+        surface_digest="sha256:" + "a" * 64,
+    )
+    after = _snapshot(
+        resources=[{"uri": "toy://r", "description": "desc2"}],
+        surface_digest="sha256:" + "b" * 64,
+    )
+    diff = diff_reports(before, after)
+    assert "Resources:" in diff
+    assert "~ toy://r" in diff
+
+
+def test_diff_reports_shows_template_metadata_changes_as_tilde_lines() -> None:
+    before = _snapshot(
+        templates=[{"uriTemplate": "toy://t/{id}", "mimeType": "text/plain"}],
+        surface_digest="sha256:" + "a" * 64,
+    )
+    after = _snapshot(
+        templates=[{"uriTemplate": "toy://t/{id}", "mimeType": "application/json"}],
+        surface_digest="sha256:" + "b" * 64,
+    )
+    diff = diff_reports(before, after)
+    assert "Resources:" in diff
+    assert "~ toy://t/{id}" in diff
+
+
+def test_diff_reports_never_claims_no_changes_when_digests_differ() -> None:
+    """
+    CLI-layer parity: if complete snapshots have different digests, the human diff must
+    not say \"No changes detected.\".
+    """
+    fixtures = Path(__file__).resolve().parent / "fixtures" / "conformance"
+    for path in sorted((fixtures / "changes").glob("*.json")):
+        fx = json.loads(path.read_text(encoding="utf-8"))
+        before_surface = fx["before"]
+        after_surface = fx["after"]
+
+        before = _wrap_surface_as_snapshot(before_surface)
+        after = _wrap_surface_as_snapshot(after_surface)
+        before["surfaceDigest"] = "sha256:" + "a" * 64
+        after["surfaceDigest"] = "sha256:" + "b" * 64
+
+        text = diff_reports(before, after)
+        assert "No changes detected" not in text, f"false negative for fixture {path.name}"
+
+
+def test_diff_reports_claims_no_changes_for_equivalence_fixtures() -> None:
+    fixtures = Path(__file__).resolve().parent / "fixtures" / "conformance"
+    for path in sorted((fixtures / "equivalence").glob("*.json")):
+        fx = json.loads(path.read_text(encoding="utf-8"))
+        a_surface = fx["a"]
+        b_surface = fx["b"]
+
+        before = _wrap_surface_as_snapshot(a_surface)
+        after = _wrap_surface_as_snapshot(b_surface)
+        before["surfaceDigest"] = "sha256:" + "a" * 64
+        after["surfaceDigest"] = "sha256:" + "a" * 64
+
+        text = diff_reports(before, after)
+        assert "No changes detected." in text, f"expected no-changes for fixture {path.name}"
 
 
 # ── Manifest / capabilities diffing ─────────────────────────

--- a/tests/test_diff_reports.py
+++ b/tests/test_diff_reports.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from mcp_preflight import diff_reports
+from mcp_preflight import _compute_snapshot_comparison, diff_reports
 
 
 def _snapshot(
@@ -254,4 +254,308 @@ def test_diff_unchanged_manifest_shows_no_capabilities_section() -> None:
     after = _snapshot(manifest_caps=manifest)
     diff = diff_reports(before, after)
     assert "Capabilities (manifest-declared):" not in diff
+
+
+def _legacy_report(
+    *,
+    server_name: str = "toy-open",
+    protocol_version: str = "2025-11-25",
+    tools: list[dict] | None = None,
+    resources: list[str] | None = None,
+    templates: list[str] | None = None,
+    prompts: list[dict] | None = None,
+) -> dict:
+    return {
+        "generatedAt": "2026-01-01T00:00:00Z",
+        "scannedCommand": ["python", "tests/toy_servers/toy_open.py"],
+        "server": {"name": server_name, "protocolVersion": protocol_version},
+        "capabilities": {"tools": True, "resources": True, "prompts": True},
+        "status": "ok",
+        "tools": tools or [],
+        "resources": resources or [],
+        "resourceTemplates": templates or [],
+        "prompts": prompts or [],
+        "risk": {"read": 0, "write": 0, "destructive": 0},
+        "signals": [],
+        "notes": [],
+        "errors": [],
+    }
+
+
+def test_legacy_schema_gap_is_rendered_as_evidence_change_not_null_to_schema() -> None:
+    legacy = _legacy_report(
+        tools=[
+            {"name": "t1", "description": "one"},
+            {"name": "t2", "description": "two"},
+        ],
+        resources=["toy://items"],
+        templates=["toy://items/{item_id}"],
+        prompts=[{"name": "analyze_items", "description": "Analyze items", "arguments": ["project_name"]}],
+    )
+    current = _snapshot(
+        server_name="toy-open",
+        tools=[
+            {"name": "t1", "description": "one", "inputSchema": {"type": "object", "properties": {"a": {"type": "string"}}}},
+            {"name": "t2", "description": "two", "inputSchema": {"type": "object"}},
+        ],
+        resources=[{"uri": "toy://items"}],
+        templates=[{"uriTemplate": "toy://items/{item_id}"}],
+        prompts=[{"name": "analyze_items", "description": "Analyze items", "arguments": [{"name": "project_name"}]}],
+        surface_digest="sha256:" + "a" * 64,
+    )
+
+    text = diff_reports(legacy, current)
+    assert "WARNING: Legacy report:" in text
+    assert "Complete-surface identity comparison: unavailable" in text
+    assert "Comparison limitations:" in text
+    assert "Newly observable:" in text
+    assert "? t1.inputSchema" in text
+    assert "? t2.inputSchema" in text
+    assert "null ->" not in text
+    assert "~ t1.inputSchema" not in text
+    assert "~ t2.inputSchema" not in text
+    assert "Resources:" not in text
+    assert "Prompts:" not in text
+    assert "No changes detected." not in text
+    assert "No proven changes detected in comparable fields." in text
+    # No redundant "identity unavailable" limitation.
+    assert "Complete-surface identity comparison is unavailable" not in text
+    # No outdated digest note wording.
+    assert "surfaceDigest is omitted unless both surfaces are complete" not in text
+
+
+def test_legacy_comparable_fields_still_diff_normally() -> None:
+    legacy = _legacy_report(
+        tools=[
+            {"name": "t1", "description": "one"},
+        ],
+        resources=[],
+        templates=[],
+        prompts=[],
+    )
+    current = _snapshot(
+        server_name="toy-open",
+        tools=[
+            {"name": "t1", "description": "ONE", "inputSchema": {"type": "object"}},
+        ],
+        resources=[],
+        templates=[],
+        prompts=[],
+        surface_digest="sha256:" + "a" * 64,
+    )
+
+    text = diff_reports(legacy, current)
+    assert "Tools:" in text
+    assert "~ t1.description:" in text
+    assert "~ t1.inputSchema" not in text
+    assert "Newly observable:" in text
+
+
+def test_compute_snapshot_comparison_emits_field_became_observable_for_legacy_schema_gap() -> None:
+    before = _snapshot(
+        tools=[
+            {"name": "t1", "description": "one", "inputSchema": None},
+            {"name": "t2", "description": "two", "inputSchema": None},
+        ],
+        resources=[],
+        templates=[],
+        prompts=[],
+        surface_digest="sha256:" + "0" * 64,
+    )
+    before["surfaceCompleteness"] = "partial"
+    before.pop("surfaceDigest", None)
+    before_obs = before.get("observation")
+    assert isinstance(before_obs, dict)
+    before_obs["comparisonMetadata"] = {
+        "legacy": True,
+        "evidenceGaps": [{"type": "field_not_captured", "entityType": "tool", "path": "/inputSchema", "reason": "legacy_format_not_captured"}],
+    }
+
+    after = _snapshot(
+        tools=[
+            {"name": "t1", "description": "one", "inputSchema": {"type": "object"}},
+            {"name": "t2", "description": "two", "inputSchema": {"type": "object"}},
+        ],
+        resources=[],
+        templates=[],
+        prompts=[],
+        surface_digest="sha256:" + "a" * 64,
+    )
+
+    comp = _compute_snapshot_comparison(before, after)
+    assert comp["identityComparable"] is False
+    ev = comp["evidenceChanges"]
+    assert any(e.get("type") == "field_became_observable" and e.get("entityId") == "t1" and e.get("path") == "/inputSchema" for e in ev)
+    assert any(e.get("type") == "field_became_observable" and e.get("entityId") == "t2" and e.get("path") == "/inputSchema" for e in ev)
+
+
+def test_generic_partial_resources_does_not_render_resource_add_remove() -> None:
+    # Before: partial due to resources timeout (resources are unknown, not empty).
+    before = _snapshot(
+        tools=[{"name": "t1", "description": "one", "inputSchema": {"type": "object"}}],
+        resources=[],
+        templates=[],
+        prompts=[],
+        surface_digest="sha256:" + "0" * 64,
+    )
+    before["surfaceCompleteness"] = "partial"
+    before.pop("surfaceDigest", None)
+    before_obs = before["observation"]
+    before_obs["coverage"] = {
+        "tools": {"attempted": True, "completed": True, "declaredSupported": True, "itemCount": 1},
+        "resources": {"attempted": True, "completed": False, "declaredSupported": True, "errorRule": "timeout"},
+        "resourceTemplates": {"attempted": True, "completed": True, "declaredSupported": True, "itemCount": 0},
+        "prompts": {"attempted": True, "completed": True, "declaredSupported": True, "itemCount": 0},
+        "manifest": {"attempted": False, "completed": False, "declaredSupported": None},
+    }
+
+    after = _snapshot(
+        tools=[{"name": "t1", "description": "one", "inputSchema": {"type": "object"}}],
+        resources=[{"uri": "toy://items"}],
+        templates=[{"uriTemplate": "toy://items/{id}"}],
+        prompts=[],
+        surface_digest="sha256:" + "a" * 64,
+    )
+
+    text = diff_reports(before, after)
+    assert "Comparison limitations:" in text
+    assert "did not complete resources inspection (timeout)" in text
+    assert "Resources:" not in text
+    assert "+ toy://items" not in text
+    assert "- toy://items" not in text
+    assert "Newly observable:" not in text
+
+
+def test_legacy_resource_uri_addition_is_still_proven() -> None:
+    legacy = _legacy_report(
+        tools=[{"name": "t1", "description": "one"}],
+        resources=["toy://a"],
+        templates=[],
+        prompts=[],
+    )
+    current = _snapshot(
+        tools=[{"name": "t1", "description": "one", "inputSchema": {"type": "object"}}],
+        resources=[{"uri": "toy://a", "description": "desc"}, {"uri": "toy://b", "description": "desc"}],
+        templates=[],
+        prompts=[],
+        surface_digest="sha256:" + "a" * 64,
+    )
+    text = diff_reports(legacy, current)
+    assert "Resources:" in text
+    assert "+ toy://b" in text
+    assert "~ toy://a" not in text
+
+
+def test_legacy_prompt_argument_name_addition_is_still_proven_prompt_change() -> None:
+    legacy = _legacy_report(
+        tools=[],
+        resources=[],
+        templates=[],
+        prompts=[{"name": "p", "description": "D", "arguments": ["a"]}],
+    )
+    current = _snapshot(
+        tools=[],
+        resources=[],
+        templates=[],
+        prompts=[
+            {
+                "name": "p",
+                "description": "D",
+                "arguments": [{"name": "a", "required": True}, {"name": "b", "required": True}],
+            }
+        ],
+        surface_digest="sha256:" + "a" * 64,
+    )
+    text = diff_reports(legacy, current)
+    assert "Prompts:" in text
+    assert "~ p.arguments:" in text
+    assert "added: b" in text
+
+
+def test_prompt_description_change_renders_detail() -> None:
+    before = _snapshot(
+        tools=[],
+        resources=[],
+        templates=[],
+        prompts=[{"name": "p", "description": "Analyze items", "arguments": [{"name": "project_name"}]}],
+        surface_digest="sha256:" + "a" * 64,
+    )
+    after = _snapshot(
+        tools=[],
+        resources=[],
+        templates=[],
+        prompts=[{"name": "p", "description": "Analyze items for a project", "arguments": [{"name": "project_name"}]}],
+        surface_digest="sha256:" + "b" * 64,
+    )
+    text = diff_reports(before, after)
+    assert "Prompts:" in text
+    assert "~ p.description:" in text
+    assert "\"Analyze items\" -> \"Analyze items for a project\"" in text
+
+
+def test_prompt_argument_name_added_and_removed_renders_detail() -> None:
+    before = _snapshot(
+        tools=[],
+        resources=[],
+        templates=[],
+        prompts=[{"name": "p", "description": "D", "arguments": [{"name": "project_name"}]}],
+        surface_digest="sha256:" + "a" * 64,
+    )
+    after = _snapshot(
+        tools=[],
+        resources=[],
+        templates=[],
+        prompts=[{"name": "p", "description": "D", "arguments": [{"name": "language"}]}],
+        surface_digest="sha256:" + "b" * 64,
+    )
+    text = diff_reports(before, after)
+    assert "Prompts:" in text
+    assert "~ p.arguments:" in text
+    assert "added: language" in text
+    assert "removed: project_name" in text
+
+
+def test_snapshot_comparison_filters_only_prompt_argument_details_not_argument_names() -> None:
+    # Before has legacy evidence gap for prompt arg details.
+    before = _snapshot(
+        tools=[],
+        resources=[],
+        templates=[],
+        prompts=[{"name": "p", "description": "D", "arguments": [{"name": "a"}]}],
+        surface_digest="sha256:" + "0" * 64,
+    )
+    before["surfaceCompleteness"] = "partial"
+    before.pop("surfaceDigest", None)
+    before["observation"]["comparisonMetadata"] = {
+        "legacy": True,
+        "evidenceGaps": [
+            {
+                "type": "fields_not_captured",
+                "entityType": "prompt",
+                "pathPattern": r"^/arguments/[^/]+/(description|required|schema)$",
+                "reason": "legacy_format_argument_details_not_captured",
+            }
+        ],
+    }
+
+    after = _snapshot(
+        tools=[],
+        resources=[],
+        templates=[],
+        prompts=[
+            {
+                "name": "p",
+                "description": "D",
+                "arguments": [{"name": "a", "required": True}, {"name": "b", "required": True}],
+            }
+        ],
+        surface_digest="sha256:" + "a" * 64,
+    )
+
+    comp = _compute_snapshot_comparison(before, after)
+    paths = [c.get("path") for c in comp["changes"] if c.get("entityType") == "prompt"]
+    # Arg-name addition should remain (value_added at /arguments/b).
+    assert "/arguments/b" in paths
+    # Nested details should be filtered (no /arguments/<arg>/required, etc.)
+    assert not any(isinstance(p, str) and p.endswith("/required") for p in paths)
 

--- a/tests/test_flags_coverage.py
+++ b/tests/test_flags_coverage.py
@@ -25,18 +25,18 @@ def test_flag_command_single_string_is_shlex_split() -> None:
     # Pass the entire server command as one argument to ensure shlex splitting path works.
     cmd = f"{sys.executable} {TOY_DIR / 'toy_open.py'}"
     proc = run_preflight_json([cmd])
-    report = json.loads(proc.stdout)
-    assert report["server"]["name"] == "toy-open"
-    assert report["status"] == "ok"
+    snap = json.loads(proc.stdout)
+    assert snap["observation"]["serverName"] == "toy-open"
+    assert snap["observation"]["status"] == "ok"
 
 
 def test_flag_timeout_triggers_timeout_status_for_non_mcp_process() -> None:
     # A non-MCP process that sleeps should cause initialize() to time out.
     proc = run_preflight_json(["--timeout", "0.3", sys.executable, "-c", "import time; time.sleep(5)"], check=False)
     assert proc.returncode != 0
-    report = json.loads(proc.stdout)
-    assert report["status"] == "timeout"
-    assert any(e.get("rule") == "timeout" for e in report.get("errors", []))
+    snap = json.loads(proc.stdout)
+    assert snap["observation"]["status"] == "timeout"
+    assert any(e.get("rule") == "timeout" for e in snap["observation"].get("errors", []))
 
 
 def test_auth_hint_on_startup_failure_prints_clean_auth_required_message() -> None:
@@ -47,8 +47,8 @@ def test_auth_hint_on_startup_failure_prints_clean_auth_required_message() -> No
         text=True,
     )
     assert proc.returncode != 0
-    report = json.loads(proc.stdout)
-    assert report["status"] == "auth_required"
+    snap = json.loads(proc.stdout)
+    assert snap["observation"]["status"] == "auth_required"
     assert "authentication required" in proc.stderr
     # Default output should be clean: stderr is hidden unless --verbose.
     assert "[server stderr]" not in proc.stderr
@@ -71,8 +71,8 @@ def test_auth_hint_startup_failure_verbose_includes_full_stderr() -> None:
         text=True,
     )
     assert proc.returncode != 0
-    report = json.loads(proc.stdout)
-    assert report["status"] == "auth_required"
+    snap = json.loads(proc.stdout)
+    assert snap["observation"]["status"] == "auth_required"
     assert "authentication required" in proc.stderr
     assert "[server stderr]" in proc.stderr
     assert "at main (" in proc.stderr
@@ -82,8 +82,8 @@ def test_flag_cwd_changes_server_working_directory() -> None:
         cwd_dir = Path(td) / "cwd-target"
         cwd_dir.mkdir(parents=True, exist_ok=True)
         proc = run_preflight_json(["--cwd", str(cwd_dir), sys.executable, str(TOY_DIR / "toy_cwd_aware.py")])
-        report = json.loads(proc.stdout)
-        tool_names = [t["name"] for t in report["tools"]]
+        snap = json.loads(proc.stdout)
+        tool_names = [t["name"] for t in snap["surface"]["tools"]]
         assert "cwd_cwd-target" in tool_names
 
 
@@ -98,8 +98,8 @@ def test_flag_env_repeatable_and_overrides_previous_value() -> None:
             str(TOY_DIR / "toy_env_aware.py"),
         ]
     )
-    report = json.loads(proc.stdout)
-    tool_names = [t["name"] for t in report["tools"]]
+    snap = json.loads(proc.stdout)
+    tool_names = [t["name"] for t in snap["surface"]["tools"]]
     assert "env_val_second" in tool_names
     assert "env_val_first" not in tool_names
 

--- a/tests/test_integration_toy_servers.py
+++ b/tests/test_integration_toy_servers.py
@@ -150,3 +150,55 @@ def test_toy_tools_only_text_output_shows_not_supported() -> None:
     assert "partial" not in proc.stdout
     assert "introspection failed" not in proc.stdout
 
+
+def test_prompts_unsupported_is_complete_and_visible() -> None:
+    snap = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_tools_only.py")])
+    cov = snap["observation"]["coverage"]["prompts"]
+    assert cov["declaredSupported"] is False
+    assert cov["attempted"] is True
+    assert cov["completed"] is True
+    assert snap["surfaceCompleteness"] == "complete"
+    assert "surfaceDigest" in snap
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "mcp_preflight", sys.executable, str(TOY_DIR / "toy_tools_only.py")],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    assert "Prompts: not supported by server" in proc.stdout
+    assert "Status: ⚠️  partial" not in proc.stdout
+
+
+def test_prompts_timeout_is_partial_and_unknown() -> None:
+    snap = parse_preflight_json(
+        ["--timeout", "1.2", sys.executable, str(TOY_DIR / "toy_partial_prompts.py")]
+    )
+    cov = snap["observation"]["coverage"]["prompts"]
+    assert cov["declaredSupported"] is True
+    assert cov["attempted"] is True
+    assert cov["completed"] is False
+    assert cov["errorRule"] == "timeout"
+    assert snap["surfaceCompleteness"] == "partial"
+    assert "surfaceDigest" not in snap
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "mcp_preflight",
+            "--timeout",
+            "1.2",
+            sys.executable,
+            str(TOY_DIR / "toy_partial_prompts.py"),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert proc.returncode != 0
+    assert "Status: ⚠️  partial" in proc.stdout
+    assert "✗ prompts (timeout)" in proc.stdout
+    assert "Prompts: unknown" in proc.stdout
+

--- a/tests/test_integration_toy_servers.py
+++ b/tests/test_integration_toy_servers.py
@@ -9,87 +9,94 @@ from conftest import TOY_DIR, parse_preflight_json, run_preflight_json
 
 
 def test_toy_open_end_to_end_enumerates_and_classifies_risk() -> None:
-    report = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_open.py")])
-    assert report["server"]["name"] == "toy-open"
-    assert report["status"] == "ok"
+    snap = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_open.py")])
+    assert snap["observation"]["serverName"] == "toy-open"
+    assert snap["observation"]["status"] == "ok"
 
-    tool_names = [t["name"] for t in report["tools"]]
+    tool_names = [t["name"] for t in snap["surface"]["tools"]]
     assert "get_item" in tool_names
     assert "create_item" in tool_names
     assert "delete_item" in tool_names
 
     # At least: get_item/list_items (read), create_item/frobnicate (write), delete_item (destructive)
-    risk = report["risk"]
+    risk = snap["observation"]["localAnnotations"]["risk"]
     assert risk["read"] >= 1
     assert risk["write"] >= 1
     assert risk["destructive"] >= 1
 
     # Resources + resource templates should both show up.
-    assert "toy://items" in report["resources"]
-    assert any("{item_id}" in uri for uri in report["resourceTemplates"])
+    res_uris = [r["uri"] for r in snap["surface"]["resources"]]
+    tmpl_uris = [t["uriTemplate"] for t in snap["surface"]["resourceTemplates"]]
+    assert "toy://items" in res_uris
+    assert any("{item_id}" in uri for uri in tmpl_uris)
 
     # Prompt should enumerate with args.
-    prompt_names = [p["name"] for p in report["prompts"]]
+    prompt_names = [p["name"] for p in snap["surface"]["prompts"]]
     assert "analyze_items" in prompt_names
 
 
 def test_toy_open_capabilities_reports_all_true() -> None:
-    report = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_open.py")])
-    caps = report["capabilities"]
+    snap = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_open.py")])
+    caps = snap["observation"]["capabilities"]
     assert caps["tools"] is True
     assert caps["resources"] is True
     assert caps["prompts"] is True
 
 
 def test_toy_auth_gated_without_token_sets_auth_gated_status() -> None:
-    report = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_auth_gated.py")])
-    assert report["server"]["name"] == "toy-auth-gated"
-    assert report["status"] == "auth_gated"
-    assert report["tools"] == []
-    assert report["resources"] == []
-    assert report["resourceTemplates"] == []
-    assert report["prompts"] == []
+    snap = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_auth_gated.py")])
+    assert snap["observation"]["serverName"] == "toy-auth-gated"
+    assert snap["observation"]["status"] == "auth_gated"
+    assert snap["surface"]["tools"] == []
+    assert snap["surface"]["resources"] == []
+    assert snap["surface"]["resourceTemplates"] == []
+    assert snap["surface"]["prompts"] == []
+    assert snap.get("surfaceDigest") is None
 
 
 def test_toy_auth_gated_with_token_enumerates() -> None:
-    report = parse_preflight_json(
+    snap = parse_preflight_json(
         ["--env", "TOY_TOKEN=ok", sys.executable, str(TOY_DIR / "toy_auth_gated.py")]
     )
-    assert report["server"]["name"] == "toy-auth-gated"
-    assert report["status"] == "ok"
-    assert any(t["name"] == "get_item" for t in report["tools"])
+    assert snap["observation"]["serverName"] == "toy-auth-gated"
+    assert snap["observation"]["status"] == "ok"
+    assert any(t["name"] == "get_item" for t in snap["surface"]["tools"])
 
 
 def test_toy_home_aware_custom_home_flag() -> None:
     with tempfile.TemporaryDirectory() as td:
         custom_home = Path(td) / "custom-home"
         custom_home.mkdir(parents=True, exist_ok=True)
-        report = parse_preflight_json(
+        snap = parse_preflight_json(
             ["--home", str(custom_home), sys.executable, str(TOY_DIR / "toy_home_aware.py")]
         )
-        tool_names = [t["name"] for t in report["tools"]]
+        tool_names = [t["name"] for t in snap["surface"]["tools"]]
         assert "home_custom_flag" in tool_names
 
 
 def test_toy_home_aware_isolate_home_flag() -> None:
-    report = parse_preflight_json(
+    snap = parse_preflight_json(
         ["--isolate-home", sys.executable, str(TOY_DIR / "toy_home_aware.py")]
     )
-    tool_names = [t["name"] for t in report["tools"]]
+    tool_names = [t["name"] for t in snap["surface"]["tools"]]
     assert "home_isolated_flag" in tool_names
 
 
 def test_toy_partial_resources_timeout_sets_partial_status_and_note() -> None:
-    report = parse_preflight_json(
-        ["--timeout", "0.8", sys.executable, str(TOY_DIR / "toy_partial_resources.py")]
+    snap = parse_preflight_json(
+        # Use a timeout comfortably above typical startup/initialize latency, but below the
+        # toy server's list_resources sleep (2.0s), so list_resources deterministically times out.
+        ["--timeout", "1.2", sys.executable, str(TOY_DIR / "toy_partial_resources.py")]
     )
-    assert report["server"]["name"] == "toy-partial-resources"
-    assert report["status"] == "partial"
-    assert any(t["name"] == "ping" for t in report["tools"])
+    assert snap["observation"]["serverName"] == "toy-partial-resources"
+    assert snap["observation"]["status"] == "partial"
+    assert snap["surfaceCompleteness"] == "partial"
+    assert any(t["name"] == "ping" for t in snap["surface"]["tools"])
     assert any(
         n.get("kind") == "mcp" and n.get("name") == "list_resources" and n.get("rule") == "timeout"
-        for n in (report.get("notes") or [])
+        for n in (snap["observation"].get("notes") or [])
     )
+    assert snap.get("surfaceDigest") is None
 
 
 # ── Tools-only server (capability-aware) ─────────────────────
@@ -97,14 +104,16 @@ def test_toy_partial_resources_timeout_sets_partial_status_and_note() -> None:
 
 def test_toy_tools_only_status_is_ok_not_partial() -> None:
     """A tools-only server should be 'ok', not 'partial' from unsupported capabilities."""
-    report = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_tools_only.py")])
-    assert report["server"]["name"] == "toy-tools-only"
-    assert report["status"] == "ok"
+    snap = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_tools_only.py")])
+    assert snap["observation"]["serverName"] == "toy-tools-only"
+    assert snap["observation"]["status"] == "ok"
+    assert snap["surfaceCompleteness"] == "complete"
+    assert snap.get("surfaceDigest")
 
 
 def test_toy_tools_only_capabilities_reflect_server() -> None:
-    report = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_tools_only.py")])
-    caps = report["capabilities"]
+    snap = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_tools_only.py")])
+    caps = snap["observation"]["capabilities"]
     assert caps["tools"] is True
     assert caps["resources"] is False
     assert caps["prompts"] is False
@@ -112,19 +121,19 @@ def test_toy_tools_only_capabilities_reflect_server() -> None:
 
 def test_toy_tools_only_no_spurious_notes() -> None:
     """No error/timeout notes should be generated for unsupported capabilities."""
-    report = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_tools_only.py")])
-    mcp_notes = [n for n in report.get("notes", []) if n.get("kind") == "mcp"]
+    snap = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_tools_only.py")])
+    mcp_notes = [n for n in snap["observation"].get("notes", []) if n.get("kind") == "mcp"]
     assert mcp_notes == []
 
 
 def test_toy_tools_only_enumerates_tools() -> None:
-    report = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_tools_only.py")])
-    tool_names = [t["name"] for t in report["tools"]]
+    snap = parse_preflight_json([sys.executable, str(TOY_DIR / "toy_tools_only.py")])
+    tool_names = [t["name"] for t in snap["surface"]["tools"]]
     assert "greet" in tool_names
     assert "get_time" in tool_names
-    assert report["resources"] == []
-    assert report["resourceTemplates"] == []
-    assert report["prompts"] == []
+    assert snap["surface"]["resources"] == []
+    assert snap["surface"]["resourceTemplates"] == []
+    assert snap["surface"]["prompts"] == []
 
 
 def test_toy_tools_only_text_output_shows_not_supported() -> None:

--- a/tests/test_output_formatting.py
+++ b/tests/test_output_formatting.py
@@ -129,12 +129,18 @@ def test_print_prompts_supported_and_empty(capsys) -> None:
 
 
 def test_introspection_coverage_all_ok(capsys) -> None:
-    report = {
-        "capabilities": {"tools": True, "resources": True, "prompts": True},
-        "notes": [],
-        "errors": [],
+    snap = {
+        "observation": {
+            "coverage": {
+                "tools": {"declaredSupported": True, "attempted": True, "completed": True},
+                "resources": {"declaredSupported": True, "attempted": True, "completed": True},
+                "resourceTemplates": {"declaredSupported": True, "attempted": True, "completed": True},
+                "prompts": {"declaredSupported": True, "attempted": True, "completed": True},
+                "manifest": {"declaredSupported": None, "attempted": False, "completed": True},
+            }
+        }
     }
-    _print_introspection_coverage(report)
+    _print_introspection_coverage(snap)
     out = capsys.readouterr().out
     assert "Introspection coverage:" in out
     assert "✓ tools" in out
@@ -143,14 +149,18 @@ def test_introspection_coverage_all_ok(capsys) -> None:
 
 
 def test_introspection_coverage_resources_timeout(capsys) -> None:
-    report = {
-        "capabilities": {"tools": True, "resources": True, "prompts": True},
-        "notes": [
-            {"kind": "mcp", "name": "list_resources", "rule": "timeout", "snippet": "Timed out after 0.8s"},
-        ],
-        "errors": [],
+    snap = {
+        "observation": {
+            "coverage": {
+                "tools": {"declaredSupported": True, "attempted": True, "completed": True},
+                "resources": {"declaredSupported": True, "attempted": True, "completed": False, "errorRule": "timeout"},
+                "resourceTemplates": {"declaredSupported": True, "attempted": True, "completed": True},
+                "prompts": {"declaredSupported": True, "attempted": True, "completed": True},
+                "manifest": {"declaredSupported": None, "attempted": False, "completed": False},
+            }
+        }
     }
-    _print_introspection_coverage(report)
+    _print_introspection_coverage(snap)
     out = capsys.readouterr().out
     assert "✓ tools" in out
     assert "✗ resources (timeout)" in out
@@ -158,14 +168,18 @@ def test_introspection_coverage_resources_timeout(capsys) -> None:
 
 
 def test_introspection_coverage_tools_error(capsys) -> None:
-    report = {
-        "capabilities": {"tools": True, "resources": True, "prompts": True},
-        "notes": [],
-        "errors": [
-            {"kind": "mcp", "name": "list_tools", "rule": "error", "snippet": "Method not found"},
-        ],
+    snap = {
+        "observation": {
+            "coverage": {
+                "tools": {"declaredSupported": True, "attempted": True, "completed": False, "errorRule": "error"},
+                "resources": {"declaredSupported": True, "attempted": True, "completed": True},
+                "resourceTemplates": {"declaredSupported": True, "attempted": True, "completed": True},
+                "prompts": {"declaredSupported": True, "attempted": True, "completed": True},
+                "manifest": {"declaredSupported": None, "attempted": False, "completed": True},
+            }
+        }
     }
-    _print_introspection_coverage(report)
+    _print_introspection_coverage(snap)
     out = capsys.readouterr().out
     assert "✗ tools (error)" in out
     assert "✓ resources" in out
@@ -173,12 +187,18 @@ def test_introspection_coverage_tools_error(capsys) -> None:
 
 def test_introspection_coverage_omits_undeclared_capabilities(capsys) -> None:
     """Resources/prompts not declared by server should not appear in coverage."""
-    report = {
-        "capabilities": {"tools": False, "resources": False, "prompts": False},
-        "notes": [],
-        "errors": [],
+    snap = {
+        "observation": {
+            "coverage": {
+                "tools": {"declaredSupported": True, "attempted": True, "completed": True},
+                "resources": {"declaredSupported": False, "attempted": False, "completed": False},
+                "resourceTemplates": {"declaredSupported": False, "attempted": False, "completed": False},
+                "prompts": {"declaredSupported": False, "attempted": False, "completed": False},
+                "manifest": {"declaredSupported": None, "attempted": False, "completed": True},
+            }
+        }
     }
-    _print_introspection_coverage(report)
+    _print_introspection_coverage(snap)
     out = capsys.readouterr().out
     assert "✓ tools" in out
     assert "resources" not in out
@@ -186,14 +206,18 @@ def test_introspection_coverage_omits_undeclared_capabilities(capsys) -> None:
 
 
 def test_introspection_coverage_prompts_timeout(capsys) -> None:
-    report = {
-        "capabilities": {"tools": True, "resources": False, "prompts": True},
-        "notes": [
-            {"kind": "mcp", "name": "list_prompts", "rule": "timeout", "snippet": "Timed out after 10s"},
-        ],
-        "errors": [],
+    snap = {
+        "observation": {
+            "coverage": {
+                "tools": {"declaredSupported": True, "attempted": True, "completed": True},
+                "resources": {"declaredSupported": False, "attempted": False, "completed": False},
+                "resourceTemplates": {"declaredSupported": False, "attempted": False, "completed": False},
+                "prompts": {"declaredSupported": True, "attempted": True, "completed": False, "errorRule": "timeout"},
+                "manifest": {"declaredSupported": None, "attempted": False, "completed": True},
+            }
+        }
     }
-    _print_introspection_coverage(report)
+    _print_introspection_coverage(snap)
     out = capsys.readouterr().out
     assert "✓ tools" in out
     assert "resources" not in out

--- a/tests/test_snapshot_digest.py
+++ b/tests/test_snapshot_digest.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from mcp_preflight import _build_snapshot, _compute_surface_digest, diff_reports
+
+
+def _complete_coverage() -> dict:
+    return {
+        "tools": {"declaredSupported": True, "attempted": True, "completed": True},
+        "resources": {"declaredSupported": False, "attempted": False, "completed": False},
+        "resourceTemplates": {"declaredSupported": False, "attempted": False, "completed": False},
+        "prompts": {"declaredSupported": False, "attempted": False, "completed": False},
+        "manifest": {"declaredSupported": None, "attempted": False, "completed": True},
+    }
+
+
+def test_surface_digest_ignores_tool_order_and_schema_property_order() -> None:
+    surface_a = {
+        "tools": [
+            {
+                "name": "a",
+                "description": "x",
+                "inputSchema": {"type": "object", "properties": {"b": {"type": "string"}, "a": {"type": "string"}}},
+            },
+            {"name": "b", "description": "y", "inputSchema": {"type": "object"}},
+        ],
+        "resources": [],
+        "resourceTemplates": [],
+        "prompts": [],
+        "declarationSources": [],
+    }
+    surface_b = {
+        "tools": [
+            {"name": "b", "description": "y", "inputSchema": {"type": "object"}},
+            {
+                "name": "a",
+                "description": "x",
+                "inputSchema": {"properties": {"a": {"type": "string"}, "b": {"type": "string"}}, "type": "object"},
+            },
+        ],
+        "resources": [],
+        "resourceTemplates": [],
+        "prompts": [],
+        "declarationSources": [],
+    }
+    assert _compute_surface_digest(surface_a) == _compute_surface_digest(surface_b)
+
+
+def test_surface_digest_excludes_protocol_version_and_timestamps() -> None:
+    surface = {
+        "tools": [{"name": "t", "description": "d", "inputSchema": {"type": "object"}}],
+        "resources": [],
+        "resourceTemplates": [],
+        "prompts": [],
+        "declarationSources": [],
+    }
+    s1 = _build_snapshot(
+        generated_at="2026-01-01T00:00:00Z",
+        scanned_command=["x"],
+        server_name="s",
+        protocol_version="2025-03-26",
+        capabilities={"tools": True, "resources": False, "prompts": False},
+        status="ok",
+        coverage=_complete_coverage(),
+        surface=surface,
+        tools_for_text=[],
+        risk={"read": 0, "write": 0, "destructive": 0},
+        signals=[],
+        notes=[],
+        errors=[],
+    )
+    s2 = _build_snapshot(
+        generated_at="2027-01-01T00:00:00Z",
+        scanned_command=["y"],
+        server_name="s",
+        protocol_version="2026-12-01",
+        capabilities={"tools": True, "resources": False, "prompts": False},
+        status="ok",
+        coverage=_complete_coverage(),
+        surface=surface,
+        tools_for_text=[],
+        risk={"read": 99, "write": 99, "destructive": 99},
+        signals=[{"kind": "tool", "name": "t", "rule": "x"}],
+        notes=[{"kind": "mcp", "name": "list_tools", "rule": "note", "snippet": "x"}],
+        errors=[],
+    )
+    assert s1["surfaceDigest"] == s2["surfaceDigest"]
+
+
+def test_description_change_changes_digest_and_diff_mentions_description() -> None:
+    before = {
+        "snapshotFormatVersion": "1",
+        "surfaceCompleteness": "complete",
+        "surface": {
+            "tools": [{"name": "t", "description": "Search messages", "inputSchema": {"type": "object"}}],
+            "resources": [],
+            "resourceTemplates": [],
+            "prompts": [],
+            "declarationSources": [],
+        },
+        "surfaceDigest": "sha256:" + "a" * 64,
+        "surfaceEntityDigests": {"tools": {}, "prompts": {}, "resources": {}, "resourceTemplates": {}},
+        "observation": {
+            "generatedAt": "x",
+            "protocolVersion": "x",
+            "serverName": "s",
+            "command": [],
+            "status": "ok",
+            "capabilities": {"tools": True, "resources": False, "prompts": False},
+            "coverage": {},
+            "notes": [],
+            "errors": [],
+            "localAnnotations": {"tools": [], "risk": {}, "signals": []},
+        },
+    }
+    after = {
+        **before,
+        "surface": {
+            **before["surface"],
+            "tools": [{"name": "t", "description": "Search messages and permanently delete matching messages", "inputSchema": {"type": "object"}}],
+        },
+        "surfaceDigest": "sha256:" + "b" * 64,
+    }
+
+    # Digest function should differ even if the placeholders above don't match real hashes.
+    assert _compute_surface_digest(before["surface"]) != _compute_surface_digest(after["surface"])
+    diff = diff_reports(before, after)
+    assert "~ t.description" in diff or "~ t.description:" in diff
+
+
+def test_schema_enum_expansion_changes_digest_and_diff_mentions_input_schema() -> None:
+    before_surface = {
+        "tools": [
+            {
+                "name": "task",
+                "description": "Task",
+                "inputSchema": {"type": "object", "properties": {"action": {"enum": ["list", "get"]}}},
+            }
+        ],
+        "resources": [],
+        "resourceTemplates": [],
+        "prompts": [],
+        "declarationSources": [],
+    }
+    after_surface = {
+        "tools": [
+            {
+                "name": "task",
+                "description": "Task",
+                "inputSchema": {"type": "object", "properties": {"action": {"enum": ["get", "list", "delete"]}}},
+            }
+        ],
+        "resources": [],
+        "resourceTemplates": [],
+        "prompts": [],
+        "declarationSources": [],
+    }
+    assert _compute_surface_digest(before_surface) != _compute_surface_digest(after_surface)
+
+    before = _build_snapshot(
+        generated_at="x",
+        scanned_command=[],
+        server_name="s",
+        protocol_version="x",
+        capabilities={"tools": True, "resources": False, "prompts": False},
+        status="ok",
+        coverage=_complete_coverage(),
+        surface=before_surface,
+        tools_for_text=[],
+        risk={"read": 0, "write": 0, "destructive": 0},
+        signals=[],
+        notes=[],
+        errors=[],
+    )
+    after = _build_snapshot(
+        generated_at="y",
+        scanned_command=[],
+        server_name="s",
+        protocol_version="x",
+        capabilities={"tools": True, "resources": False, "prompts": False},
+        status="ok",
+        coverage=_complete_coverage(),
+        surface=after_surface,
+        tools_for_text=[],
+        risk={"read": 0, "write": 0, "destructive": 0},
+        signals=[],
+        notes=[],
+        errors=[],
+    )
+    diff = diff_reports(before, after)
+    assert "~ task.inputSchema" in diff
+

--- a/tests/toy_servers/toy_manifest_dupe_ops.py
+++ b/tests/toy_servers/toy_manifest_dupe_ops.py
@@ -1,0 +1,49 @@
+"""
+Toy MCP server exposing a malformed ://mcp/manifest resource.
+
+Specifically: the manifest declares duplicate operation values for a dispatched tool.
+This should cause mcp-preflight to mark manifest inspection incomplete, mark the
+surface partial, and suppress surfaceDigest emission.
+"""
+
+from __future__ import annotations
+
+import json
+
+import anyio
+from mcp.server.fastmcp import FastMCP
+
+
+mcp = FastMCP(name="toy-manifest-dupe-ops", instructions="Toy server with duplicate manifest operations.")
+
+
+MANIFEST_PAYLOAD = {
+    "version": "1.0.0",
+    "tools": {
+        "task": {
+            "description": "Task management",
+            "dispatch_key": "action",
+            # Duplicate value is malformed.
+            "operations": ["list", "get", "get"],
+        }
+    },
+}
+
+
+@mcp.resource("toy://mcp/manifest", description="Server capabilities manifest (malformed)")
+def manifest() -> str:
+    return json.dumps(MANIFEST_PAYLOAD)
+
+
+@mcp.tool(description="Task management")
+def task(action: str) -> str:
+    return f"task:{action}"
+
+
+def main() -> None:
+    anyio.run(mcp.run_stdio_async)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/toy_servers/toy_partial_prompts.py
+++ b/tests/toy_servers/toy_partial_prompts.py
@@ -1,0 +1,42 @@
+"""
+Toy MCP server (stdio) that intentionally times out on list_prompts.
+
+Used to deterministically test mcp-preflight's distinction between:
+- prompts unsupported (toy_tools_only.py) -> complete surface + digest
+- prompts supported but list_prompts fails -> partial surface + no digest
+"""
+
+from __future__ import annotations
+
+import anyio
+
+from mcp.server.fastmcp import FastMCP
+
+
+class SlowListPromptsMCP(FastMCP):
+    async def list_prompts(self):  # type: ignore[override]
+        # Sleep long enough to exceed the test timeout, but still bounded.
+        await anyio.sleep(5.0)
+        return await super().list_prompts()
+
+
+mcp = SlowListPromptsMCP(name="toy-partial-prompts", instructions="Toy server for partial prompts status tests.")
+
+
+@mcp.tool(description="Always present")
+def ping() -> str:
+    return "pong"
+
+
+@mcp.prompt(description="Analyze a project")
+def analyze(project: str) -> str:
+    return f"Analyze {project}"
+
+
+def main() -> None:
+    anyio.run(mcp.run_stdio_async)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/uv.lock
+++ b/uv.lock
@@ -347,12 +347,20 @@ test = [
     { name = "pytest" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "mcp", specifier = ">=1.26.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
 ]
 provides-extras = ["test"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.0.0" }]
 
 [[package]]
 name = "packaging"

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,12 @@
 version = 1
 revision = 3
 requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
+]
 
 [[package]]
 name = "annotated-types"
@@ -148,62 +154,59 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.5"
+version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/04/ee2a9e8542e4fa2773b81771ff8349ff19cdd56b7258a0cc442639052edb/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d", size = 750064, upload-time = "2026-02-10T19:18:38.255Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/81/b0bb27f2ba931a65409c6b8a8b358a7f03c0e46eceacddff55f7c84b1f3b/cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad", size = 7176289, upload-time = "2026-02-10T19:17:08.274Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/9e/6b4397a3e3d15123de3b1806ef342522393d50736c13b20ec4c9ea6693a6/cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b", size = 4275637, upload-time = "2026-02-10T19:17:10.53Z" },
-    { url = "https://files.pythonhosted.org/packages/63/e7/471ab61099a3920b0c77852ea3f0ea611c9702f651600397ac567848b897/cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b", size = 4424742, upload-time = "2026-02-10T19:17:12.388Z" },
-    { url = "https://files.pythonhosted.org/packages/37/53/a18500f270342d66bf7e4d9f091114e31e5ee9e7375a5aba2e85a91e0044/cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263", size = 4277528, upload-time = "2026-02-10T19:17:13.853Z" },
-    { url = "https://files.pythonhosted.org/packages/22/29/c2e812ebc38c57b40e7c583895e73c8c5adb4d1e4a0cc4c5a4fdab2b1acc/cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d", size = 4947993, upload-time = "2026-02-10T19:17:15.618Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/e7/237155ae19a9023de7e30ec64e5d99a9431a567407ac21170a046d22a5a3/cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed", size = 4456855, upload-time = "2026-02-10T19:17:17.221Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/87/fc628a7ad85b81206738abbd213b07702bcbdada1dd43f72236ef3cffbb5/cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2", size = 3984635, upload-time = "2026-02-10T19:17:18.792Z" },
-    { url = "https://files.pythonhosted.org/packages/84/29/65b55622bde135aedf4565dc509d99b560ee4095e56989e815f8fd2aa910/cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2", size = 4277038, upload-time = "2026-02-10T19:17:20.256Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/36/45e76c68d7311432741faf1fbf7fac8a196a0a735ca21f504c75d37e2558/cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0", size = 4912181, upload-time = "2026-02-10T19:17:21.825Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/1a/c1ba8fead184d6e3d5afcf03d569acac5ad063f3ac9fb7258af158f7e378/cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731", size = 4456482, upload-time = "2026-02-10T19:17:25.133Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/e5/3fb22e37f66827ced3b902cf895e6a6bc1d095b5b26be26bd13c441fdf19/cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82", size = 4405497, upload-time = "2026-02-10T19:17:26.66Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/df/9d58bb32b1121a8a2f27383fabae4d63080c7ca60b9b5c88be742be04ee7/cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1", size = 4667819, upload-time = "2026-02-10T19:17:28.569Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/ed/325d2a490c5e94038cdb0117da9397ece1f11201f425c4e9c57fe5b9f08b/cryptography-46.0.5-cp311-abi3-win32.whl", hash = "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48", size = 3028230, upload-time = "2026-02-10T19:17:30.518Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/5a/ac0f49e48063ab4255d9e3b79f5def51697fce1a95ea1370f03dc9db76f6/cryptography-46.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4", size = 3480909, upload-time = "2026-02-10T19:17:32.083Z" },
-    { url = "https://files.pythonhosted.org/packages/00/13/3d278bfa7a15a96b9dc22db5a12ad1e48a9eb3d40e1827ef66a5df75d0d0/cryptography-46.0.5-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:94a76daa32eb78d61339aff7952ea819b1734b46f73646a07decb40e5b3448e2", size = 7119287, upload-time = "2026-02-10T19:17:33.801Z" },
-    { url = "https://files.pythonhosted.org/packages/67/c8/581a6702e14f0898a0848105cbefd20c058099e2c2d22ef4e476dfec75d7/cryptography-46.0.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678", size = 4265728, upload-time = "2026-02-10T19:17:35.569Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/4a/ba1a65ce8fc65435e5a849558379896c957870dd64fecea97b1ad5f46a37/cryptography-46.0.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87", size = 4408287, upload-time = "2026-02-10T19:17:36.938Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/67/8ffdbf7b65ed1ac224d1c2df3943553766914a8ca718747ee3871da6107e/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee", size = 4270291, upload-time = "2026-02-10T19:17:38.748Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/e5/f52377ee93bc2f2bba55a41a886fd208c15276ffbd2569f2ddc89d50e2c5/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981", size = 4927539, upload-time = "2026-02-10T19:17:40.241Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/02/cfe39181b02419bbbbcf3abdd16c1c5c8541f03ca8bda240debc467d5a12/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9", size = 4442199, upload-time = "2026-02-10T19:17:41.789Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/96/2fcaeb4873e536cf71421a388a6c11b5bc846e986b2b069c79363dc1648e/cryptography-46.0.5-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648", size = 3960131, upload-time = "2026-02-10T19:17:43.379Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/d2/b27631f401ddd644e94c5cf33c9a4069f72011821cf3dc7309546b0642a0/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4", size = 4270072, upload-time = "2026-02-10T19:17:45.481Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/a7/60d32b0370dae0b4ebe55ffa10e8599a2a59935b5ece1b9f06edb73abdeb/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0", size = 4892170, upload-time = "2026-02-10T19:17:46.997Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/b9/cf73ddf8ef1164330eb0b199a589103c363afa0cf794218c24d524a58eab/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663", size = 4441741, upload-time = "2026-02-10T19:17:48.661Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/eb/eee00b28c84c726fe8fa0158c65afe312d9c3b78d9d01daf700f1f6e37ff/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826", size = 4396728, upload-time = "2026-02-10T19:17:50.058Z" },
-    { url = "https://files.pythonhosted.org/packages/65/f4/6bc1a9ed5aef7145045114b75b77c2a8261b4d38717bd8dea111a63c3442/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d", size = 4652001, upload-time = "2026-02-10T19:17:51.54Z" },
-    { url = "https://files.pythonhosted.org/packages/86/ef/5d00ef966ddd71ac2e6951d278884a84a40ffbd88948ef0e294b214ae9e4/cryptography-46.0.5-cp314-cp314t-win32.whl", hash = "sha256:c3bcce8521d785d510b2aad26ae2c966092b7daa8f45dd8f44734a104dc0bc1a", size = 3003637, upload-time = "2026-02-10T19:17:52.997Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/57/f3f4160123da6d098db78350fdfd9705057aad21de7388eacb2401dceab9/cryptography-46.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:4d8ae8659ab18c65ced284993c2265910f6c9e650189d4e3f68445ef82a810e4", size = 3469487, upload-time = "2026-02-10T19:17:54.549Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/fa/a66aa722105ad6a458bebd64086ca2b72cdd361fed31763d20390f6f1389/cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31", size = 7170514, upload-time = "2026-02-10T19:17:56.267Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/04/c85bdeab78c8bc77b701bf0d9bdcf514c044e18a46dcff330df5448631b0/cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18", size = 4275349, upload-time = "2026-02-10T19:17:58.419Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/32/9b87132a2f91ee7f5223b091dc963055503e9b442c98fc0b8a5ca765fab0/cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235", size = 4420667, upload-time = "2026-02-10T19:18:00.619Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/a6/a7cb7010bec4b7c5692ca6f024150371b295ee1c108bdc1c400e4c44562b/cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a", size = 4276980, upload-time = "2026-02-10T19:18:02.379Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/7c/c4f45e0eeff9b91e3f12dbd0e165fcf2a38847288fcfd889deea99fb7b6d/cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76", size = 4939143, upload-time = "2026-02-10T19:18:03.964Z" },
-    { url = "https://files.pythonhosted.org/packages/37/19/e1b8f964a834eddb44fa1b9a9976f4e414cbb7aa62809b6760c8803d22d1/cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614", size = 4453674, upload-time = "2026-02-10T19:18:05.588Z" },
-    { url = "https://files.pythonhosted.org/packages/db/ed/db15d3956f65264ca204625597c410d420e26530c4e2943e05a0d2f24d51/cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229", size = 3978801, upload-time = "2026-02-10T19:18:07.167Z" },
-    { url = "https://files.pythonhosted.org/packages/41/e2/df40a31d82df0a70a0daf69791f91dbb70e47644c58581d654879b382d11/cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1", size = 4276755, upload-time = "2026-02-10T19:18:09.813Z" },
-    { url = "https://files.pythonhosted.org/packages/33/45/726809d1176959f4a896b86907b98ff4391a8aa29c0aaaf9450a8a10630e/cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d", size = 4901539, upload-time = "2026-02-10T19:18:11.263Z" },
-    { url = "https://files.pythonhosted.org/packages/99/0f/a3076874e9c88ecb2ecc31382f6e7c21b428ede6f55aafa1aa272613e3cd/cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c", size = 4452794, upload-time = "2026-02-10T19:18:12.914Z" },
-    { url = "https://files.pythonhosted.org/packages/02/ef/ffeb542d3683d24194a38f66ca17c0a4b8bf10631feef44a7ef64e631b1a/cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4", size = 4404160, upload-time = "2026-02-10T19:18:14.375Z" },
-    { url = "https://files.pythonhosted.org/packages/96/93/682d2b43c1d5f1406ed048f377c0fc9fc8f7b0447a478d5c65ab3d3a66eb/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9", size = 4667123, upload-time = "2026-02-10T19:18:15.886Z" },
-    { url = "https://files.pythonhosted.org/packages/45/2d/9c5f2926cb5300a8eefc3f4f0b3f3df39db7f7ce40c8365444c49363cbda/cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72", size = 3010220, upload-time = "2026-02-10T19:18:17.361Z" },
-    { url = "https://files.pythonhosted.org/packages/48/ef/0c2f4a8e31018a986949d34a01115dd057bf536905dca38897bacd21fac3/cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595", size = 3467050, upload-time = "2026-02-10T19:18:18.899Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/dd/2d9fdb07cebdf3d51179730afb7d5e576153c6744c3ff8fded23030c204e/cryptography-46.0.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:3b4995dc971c9fb83c25aa44cf45f02ba86f71ee600d81091c2f0cbae116b06c", size = 3476964, upload-time = "2026-02-10T19:18:20.687Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/6f/6cc6cc9955caa6eaf83660b0da2b077c7fe8ff9950a3c5e45d605038d439/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:bc84e875994c3b445871ea7181d424588171efec3e185dced958dad9e001950a", size = 4218321, upload-time = "2026-02-10T19:18:22.349Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/5d/c4da701939eeee699566a6c1367427ab91a8b7088cc2328c09dbee940415/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:2ae6971afd6246710480e3f15824ed3029a60fc16991db250034efd0b9fb4356", size = 4381786, upload-time = "2026-02-10T19:18:24.529Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/97/a538654732974a94ff96c1db621fa464f455c02d4bb7d2652f4edc21d600/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d861ee9e76ace6cf36a6a89b959ec08e7bc2493ee39d07ffe5acb23ef46d27da", size = 4217990, upload-time = "2026-02-10T19:18:25.957Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/11/7e500d2dd3ba891197b9efd2da5454b74336d64a7cc419aa7327ab74e5f6/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:2b7a67c9cd56372f3249b39699f2ad479f6991e62ea15800973b956f4b73e257", size = 4381252, upload-time = "2026-02-10T19:18:27.496Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/58/6b3d24e6b9bc474a2dcdee65dfd1f008867015408a271562e4b690561a4d/cryptography-46.0.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8456928655f856c6e1533ff59d5be76578a7157224dbd9ce6872f25055ab9ab7", size = 3407605, upload-time = "2026-02-10T19:18:29.233Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d3/4a83af35d65e3fad632c926fad684c193ea4398569ccb0bbbc7fe8f5dc9a/cryptography-49.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc1e275c2f1d97b1a6450b8b0ea3ebfa6e087a611c2b26cb2404d48588abab7b", size = 3993685, upload-time = "2026-06-12T20:02:14.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a7/f9dac0ab7f80368c56993a7bf638ef9935f825c91902798481fac0898138/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838", size = 4676239, upload-time = "2026-06-12T20:02:28.793Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/70/2ba3769dd0ae167e2f33dfa9592d45db6ff9a61d62ca1a5b3d1bdd09068f/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5", size = 4715584, upload-time = "2026-06-12T20:01:27.495Z" },
+    { url = "https://files.pythonhosted.org/packages/94/64/2923570ac1c0bd3a737aa366ac3abbbbde273042308b8cde95e2364a6e6a/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615", size = 4675885, upload-time = "2026-06-12T20:01:55.49Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/614dc7e051418cfe53d55173c1e24c6b0085e89996fe90508c2fdf769aef/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6", size = 4715449, upload-time = "2026-06-12T20:02:05.469Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/50/a9caea39ad19c431c1a3f8a31114df65b260cdfe67786b6c7e7c040c4c44/cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6", size = 3783731, upload-time = "2026-06-12T20:02:43.319Z" },
 ]
 
 [[package]]
@@ -266,11 +269,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -311,7 +314,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -329,9 +332,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]
@@ -524,34 +527,37 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.12.0"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]
@@ -561,7 +567,7 @@ crypto = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -572,27 +578,27 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
@@ -768,15 +774,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Fix Dependabot-reported Python dependency vulnerabilities via targeted `uv.lock` upgrades.
- Refresh README positioning around snapshot + check, add snapshot-format docs.
- Improve CLI UX: show surfaceDigest in `inspect`, add a concise `Surface changed.` summary for diffs, and make `check` fail cleanly when the baseline path is missing.

## Test plan
- [x] `uv sync --dev`
- [x] `uv run pytest -q`
- [x] `uv run mcp-preflight check tests/baselines/toy-open.snapshot.json "python tests/toy_servers/toy_open.py"`
